### PR TITLE
Added some functionality to toggle whether if the password in the fie…

### DIFF
--- a/resources/js/backend.js
+++ b/resources/js/backend.js
@@ -1,4 +1,5 @@
 import './bootstrap';
+import {initPasswordFields} from './password-toggle';
 import '@coreui/coreui'
 
 /**
@@ -101,6 +102,11 @@ $(document).ready(function() {
             searchPlaceholder: "Search..."
         }
     }).order([2, 'desc']).draw();
+
+    /**
+     * Initialise the password toggle fields.
+     */
+    initPasswordFields();
 });
 
 

--- a/resources/js/password-toggle.js
+++ b/resources/js/password-toggle.js
@@ -1,0 +1,31 @@
+/**
+ * Export this field so that it can be called in other files.
+ */
+export function initPasswordFields() {
+    bindEvents();
+}
+
+/**
+ * Bind the events that are related to password field toggling.
+ */
+function bindEvents() {
+    $('body').on('click', '.password-toggler', togglePasswordField);
+}
+
+/**
+ * After the toggler has been clicked, show/hide the password
+ * in the input field.
+ */
+function togglePasswordField() {
+    let $inputField = $(this).closest('.password-toggler-container').find('input');
+
+    if ($inputField.attr('type') === 'text') {
+        $inputField.attr('type', 'password');
+        $(this).find('.fa-eye').removeClass('d-none');
+        $(this).find('.fa-eye-slash').addClass('d-none');
+    } else {
+        $inputField.attr('type', 'text');
+        $(this).find('.fa-eye').addClass('d-none');
+        $(this).find('.fa-eye-slash').removeClass('d-none');
+    }
+}

--- a/resources/sass/backend.scss
+++ b/resources/sass/backend.scss
@@ -274,3 +274,17 @@ body {
 .statistics {
 
 }
+
+//
+// Password Toggler
+//
+.password-toggler {
+  border: none;
+  transition: 0.1s all ease-out;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #c5c7ca;
+  }
+}
+

--- a/resources/views/backend/user/changepassword.blade.php
+++ b/resources/views/backend/user/changepassword.blade.php
@@ -33,7 +33,15 @@
               <label for="new-password" class="col-sm-3 col-form-label">@lang('New Password')</label>
 
               <div class="col">
-                <input id="new-password" type="password" class="form-control" name="new-password" placeholder="Enter a new password" required>
+                <div class="input-group password-toggler-container">
+                  <input type="password" class="form-control" id="new-password" name="new-password" aria-label="Enter a new password" placeholder="Enter a new password" required>
+                  <div class="input-group-append">
+                    <span class="input-group-text password-toggler">
+                      <i class="fa fa-eye-slash"></i>
+                      <i class="fa fa-eye d-none"></i>
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
 
@@ -41,7 +49,15 @@
               <label for="new-password-confirm" class="col-sm-3 col-form-label">@lang('Confirmation')</label>
 
               <div class="col">
-                <input id="new-password-confirm" type="password" class="form-control" name="new-password_confirmation" placeholder="Retype the new password" required>
+                <div class="input-group password-toggler-container">
+                  <input type="password" class="form-control" id="new-password-confirm" name="new-password_confirmation" aria-label="Retype the new password" placeholder="Retype the new password" required>
+                  <div class="input-group-append">
+                    <span class="input-group-text password-toggler">
+                      <i class="fa fa-eye-slash"></i>
+                      <i class="fa fa-eye d-none"></i>
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
***Added some functionality to toggle whether if the password in the field is displayed in plain-text.***

Apologies if I've done any of this wrong. If needed, I can make any changes to get it ready for pulling in.

This PR adds an 'eye' icon on the password fields in the 'change password' form. By clicking the icon, you can toggle between seeing the password in plain-text or not. Hopefully, this is something that is pretty useful? :)

I haven't committed the built assets (from the 'public' folder) but I can do if needed.