### PR TITLE
Move url_key remaining (%) to the model

### DIFF
--- a/app/Http/Controllers/Backend/DashboardController.php
+++ b/app/Http/Controllers/Backend/DashboardController.php
@@ -45,6 +45,7 @@ class DashboardController extends Controller
             'totalGuest'           => $user->totalGuest(),
             'capacity'             => $this->url->url_key_capacity(),
             'remaining'            => $this->url->url_key_remaining(),
+            'remaining_percent'    => $this->url->url_key_remaining_percent(),
         ]);
     }
 

--- a/app/Url.php
+++ b/app/Url.php
@@ -188,6 +188,25 @@ class Url extends Model
     }
 
     /**
+     * @return string
+     */
+    public function url_key_remaining_percent()
+    {
+        $capacity = $this->url_key_capacity();
+        $remaining = $this->url_key_remaining();
+
+        if ($capacity == 0) {
+            return '(0%)';
+        } else {
+            if (round(($remaining * 100) / $capacity, 3) == 100) {
+                return '(99.99%)';
+            } else {
+                return '('.round(($remaining * 100) / $capacity).'%)';
+            }
+        }
+    }
+
+    /**
      * Gets the title of page from its url.
      *
      * @param string $url

--- a/app/Url.php
+++ b/app/Url.php
@@ -196,12 +196,12 @@ class Url extends Model
         $remaining = $this->url_key_remaining();
 
         if ($capacity == 0) {
-            return '(0%)';
+            return '0%';
         } else {
             if ((round(($remaining * 100) / $capacity, 2) == 100) && ($capacity != $remaining)) {
-                return '(99.99%)';
+                return '99.99%';
             } else {
-                return '('.round(($remaining * 100) / $capacity).'%)';
+                return round(($remaining * 100) / $capacity).'%';
             }
         }
     }

--- a/app/Url.php
+++ b/app/Url.php
@@ -198,7 +198,7 @@ class Url extends Model
         if ($capacity == 0) {
             return '(0%)';
         } else {
-            if (round(($remaining * 100) / $capacity, 3) == 100) {
+            if ((round(($remaining * 100) / $capacity, 2) == 100) && ($capacity != $remaining)) {
                 return '(99.99%)';
             } else {
                 return '('.round(($remaining * 100) / $capacity).'%)';

--- a/resources/views/backend/partials/stat.blade.php
+++ b/resources/views/backend/partials/stat.blade.php
@@ -17,11 +17,7 @@
           <div class="col col-sm">
             <span title="{{number_format($remaining)}}" data-toggle="tooltip">
               {{number_format_short($remaining)}}
-              @if ($capacity == 0)
-                (0%)
-              @else
-                ({{round(100-((($capacity-$remaining)/$capacity)*100))}}%)
-              @endif
+              {{$remaining_percent}}
             </span>
           </div>
         </div>

--- a/resources/views/backend/partials/stat.blade.php
+++ b/resources/views/backend/partials/stat.blade.php
@@ -17,7 +17,7 @@
           <div class="col col-sm">
             <span title="{{number_format($remaining)}}" data-toggle="tooltip">
               {{number_format_short($remaining)}}
-              {{$remaining_percent}}
+              ({{$remaining_percent}})
             </span>
           </div>
         </div>

--- a/tests/Unit/Models/UrlTest.php
+++ b/tests/Unit/Models/UrlTest.php
@@ -280,17 +280,17 @@ class UrlTest extends TestCase
         config()->set('urlhub.hash_length', 2);
         config()->set('urlhub.hash_alphabet', 'ab');
 
-        $this->assertSame('(0%)', $this->url->url_key_remaining_percent());
+        $this->assertSame('0%', $this->url->url_key_remaining_percent());
 
         config()->set('urlhub.hash_length', 6);
         config()->set('urlhub.hash_alphabet', 'abcdefghij');
 
-        $this->assertSame('(99.99%)', $this->url->url_key_remaining_percent());
+        $this->assertSame('99.99%', $this->url->url_key_remaining_percent());
 
         config()->set('urlhub.hash_length', 3);
         config()->set('urlhub.hash_alphabet', 'abcdefg');
 
-        $this->assertSame('(98%)', $this->url->url_key_remaining_percent());
+        $this->assertSame('98%', $this->url->url_key_remaining_percent());
     }
 
     /**

--- a/tests/Unit/Models/UrlTest.php
+++ b/tests/Unit/Models/UrlTest.php
@@ -275,9 +275,22 @@ class UrlTest extends TestCase
      */
     public function url_key_remaining_percent()
     {
-        factory(Url::class, 5)->create();
+        factory(Url::class, 4)->create();
 
-        config()->set('urlhub.hash_length', 1);
+        config()->set('urlhub.hash_length', 2);
+        config()->set('urlhub.hash_alphabet', 'ab');
+
+        $this->assertSame('(0%)', $this->url->url_key_remaining_percent());
+
+        config()->set('urlhub.hash_length', 6);
+        config()->set('urlhub.hash_alphabet', 'abcdefghij');
+
+        $this->assertSame('(99.99%)', $this->url->url_key_remaining_percent());
+
+        config()->set('urlhub.hash_length', 3);
+        config()->set('urlhub.hash_alphabet', 'abcdefg');
+
+        $this->assertSame('(98%)', $this->url->url_key_remaining_percent());
     }
 
     /**

--- a/tests/Unit/Models/UrlTest.php
+++ b/tests/Unit/Models/UrlTest.php
@@ -271,6 +271,18 @@ class UrlTest extends TestCase
     /**
      * @test
      * @group u-model
+     * @covers ::url_key_remaining
+     */
+    public function url_key_remaining_percent()
+    {
+        factory(Url::class, 5)->create();
+
+        config()->set('urlhub.hash_length', 1);
+    }
+
+    /**
+     * @test
+     * @group u-model
      * @covers ::getTitle
      */
     public function getTitle()


### PR DESCRIPTION
Previously the calculation of the percentage of the remaining keys was done directly on the blade, now the calculation function is coded on the model.