### PR TITLE
Added support to serve redirects with status 301 and Cache-Control

### DIFF
--- a/app/Services/UrlRedirectionService.php
+++ b/app/Services/UrlRedirectionService.php
@@ -35,10 +35,14 @@ class UrlRedirectionService
      */
     public function handleHttpRedirect(Url $url)
     {
+        $headers = [
+            'Cache-Control' => sprintf('private,max-age=%s', uHub('redirect_cache_lifetime')),
+        ];
+
         $url->increment('clicks');
         $this->createUrlStat($url, $url->ipToCountry(request()->ip()));
 
-        return redirect()->away($url->long_url, uHub('redirect_status_code'));
+        return redirect()->away($url->long_url, uHub('redirect_status_code'), $headers);
     }
 
     /**

--- a/app/Services/UrlRedirectionService.php
+++ b/app/Services/UrlRedirectionService.php
@@ -35,12 +35,12 @@ class UrlRedirectionService
      */
     public function handleHttpRedirect(Url $url)
     {
+        $url->increment('clicks');
+        $this->createUrlStat($url, $url->ipToCountry(request()->ip()));
+
         $headers = [
             'Cache-Control' => sprintf('private,max-age=%s', uHub('redirect_cache_lifetime')),
         ];
-
-        $url->increment('clicks');
-        $this->createUrlStat($url, $url->ipToCountry(request()->ip()));
 
         return redirect()->away($url->long_url, uHub('redirect_status_code'), $headers);
     }

--- a/config/urlhub.php
+++ b/config/urlhub.php
@@ -57,7 +57,7 @@ return [
      * can either set:
      * - 301 (Default behavior. Visitors always hit the server)
      * - 302 (Better for SEO. Visitors hit the server the first time and then
-     *   cache the redirect)
+     *   cache the redirect).
      *
      * When selecting 301 redirects, you can also configure the time redirects
      * are cached, to mitigate deviations in stats.

--- a/config/urlhub.php
+++ b/config/urlhub.php
@@ -55,8 +55,8 @@ return [
     /**
      * Configure the kind of redirect you want to use for your short URLs. You
      * can either set:
-     * - 301 (Default behavior. Visitors always hit the server).
-     * - 302 (Better for SEO. Visitors hit the server the first time and then
+     * - 301 (Default behavior, visitors always hit the server).
+     * - 302 (Better for SEO, visitors hit the server the first time and then
      *   cache the redirect).
      *
      * When selecting 301 redirects, you can also configure the time redirects

--- a/config/urlhub.php
+++ b/config/urlhub.php
@@ -53,22 +53,21 @@ return [
     ),
 
     /**
-     * The HTTP redirect code, redirect for short, is a way to forward visitors
-     * and search engines from one URL to another.
+     * Configure the kind of redirect you want to use for your short URLs. You
+     * can either set:
+     * - 301 (Default behavior. Visitors always hit the server)
+     * - 302 (Better for SEO. Visitors hit the server the first time and then
+     * cache the redirect)
      *
-     * Not all redirection is treated equally; the redirection instruction sent
-     * to a browser can contain in its header the HTTP status:
-     * - 301 (Moved Permanently)
-     * - 302 (Found)
-     * - 307 (Temporary Redirect)
-     * - 308 (Permanent Redirect)
-     *
-     * You can read the references below to find out what code is good to use.
-     * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
-     * - https://redirectdetective.com/redirection-types.html
+     * When selecting 301 redirects, you can also configure the time redirects
+     * are cached, to mitigate deviations in stats.
      */
     'redirect_status_code' => env('UH_REDIRECT_STATUS_CODE', 301),
 
+    /**
+     * Set the amount of seconds that redirects should be cached when redirect
+     * status is 301. Default values is 90.
+     */
     'redirect_cache_lifetime' => env('UH_REDIRECT_CACHE_LIFETIME', 90),
 
     /**

--- a/config/urlhub.php
+++ b/config/urlhub.php
@@ -57,7 +57,7 @@ return [
      * can either set:
      * - 301 (Default behavior. Visitors always hit the server)
      * - 302 (Better for SEO. Visitors hit the server the first time and then
-     * cache the redirect).
+     *   cache the redirect)
      *
      * When selecting 301 redirects, you can also configure the time redirects
      * are cached, to mitigate deviations in stats.

--- a/config/urlhub.php
+++ b/config/urlhub.php
@@ -55,7 +55,7 @@ return [
     /**
      * Configure the kind of redirect you want to use for your short URLs. You
      * can either set:
-     * - 301 (Default behavior. Visitors always hit the server)
+     * - 301 (Default behavior. Visitors always hit the server).
      * - 302 (Better for SEO. Visitors hit the server the first time and then
      *   cache the redirect).
      *

--- a/config/urlhub.php
+++ b/config/urlhub.php
@@ -57,7 +57,7 @@ return [
      * can either set:
      * - 301 (Default behavior. Visitors always hit the server)
      * - 302 (Better for SEO. Visitors hit the server the first time and then
-     * cache the redirect)
+     * cache the redirect).
      *
      * When selecting 301 redirects, you can also configure the time redirects
      * are cached, to mitigate deviations in stats.

--- a/config/urlhub.php
+++ b/config/urlhub.php
@@ -67,7 +67,9 @@ return [
      * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
      * - https://redirectdetective.com/redirection-types.html
      */
-    'redirect_status_code' => env('UH_REDIRECT_STATUS_CODE', 302),
+    'redirect_status_code' => env('UH_REDIRECT_STATUS_CODE', 301),
+
+    'redirect_cache_lifetime' => env('UH_REDIRECT_CACHE_LIFETIME', 90),
 
     /**
      * List of non allowed domain.


### PR DESCRIPTION
Implement permanent redirects with a Cache-Control header as a configuration option when creating a link so users can consciously choose the desired behaviour.