### PR TITLE
Forggeting the session login_error after refresh the login page

### DIFF
--- a/resources/views/frontend/auth/login.blade.php
+++ b/resources/views/frontend/auth/login.blade.php
@@ -16,6 +16,7 @@
         <span aria-hidden="true">&times;</span>
       </button>
     </div>
+    {{ session()->forget('login_error') }}
   @endif
 
   <div class="w-full sm:max-w-md mt-6 px-12 py-8 overflow-hidden sm:rounded-lg


### PR DESCRIPTION
Hello guys. Currently if you insert wrong login credentials, the login page return the following:  These credentials do not match our records. 

That message persists even after refresh the page, going to home page and backing to the login page. I just added a session()->forget('login_error') to the page. That code runs always the page has a login_error but only after the page display the error. 

What do you guys think about that approach?