### PR TITLE
Use the new way of declaring accessors and mutators

### DIFF
--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -98,20 +98,21 @@ class Url extends Model
         );
     }
 
-    /**
-     * @return void
-     */
-    public function setMetaTitleAttribute(string $value)
+    protected function metaTitle(): Attribute
     {
-        $this->attributes['meta_title'] = 'No Title';
+        return Attribute::make(
+            set: function ($value, $attributes) {
+                if (config('urlhub.web_title')) {
+                    return $this->attributes['meta_title'] = $value;
 
-        if (config('urlhub.web_title')) {
-            $this->attributes['meta_title'] = $value;
+                    if (Str::startsWith($value, 'http')) {
+                        return $this->attributes['meta_title'] = $this->getWebTitle($value);
+                    }
+                }
 
-            if (Str::startsWith($value, 'http')) {
-                $this->attributes['meta_title'] = $this->getWebTitle($value);
-            }
-        }
+                return $this->attributes['meta_title'] = 'No Title';
+            },
+        );
     }
 
     public function shortUrl(): Attribute

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -80,7 +80,7 @@ class Url extends Model
 
     /*
     |--------------------------------------------------------------------------
-    | Accessors & Mutators
+    | Eloquent: Accessors & Mutators
     |--------------------------------------------------------------------------
     |
     | Accessors and mutators allow you to format Eloquent attribute values when

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -14,6 +14,12 @@ use RandomLib\Factory as RandomLibFactory;
 use Spatie\Url\Url as SpatieUrl;
 use Symfony\Component\HttpFoundation\IpUtils;
 
+/**
+ * @property int|null $user_id
+ * @property string   $short_url
+ * @property string   $long_url
+ * @property string   $meta_title
+ */
 class Url extends Model
 {
     use HasFactory;

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -115,7 +115,7 @@ class Url extends Model
         );
     }
 
-    public function shortUrl(): Attribute
+    protected function shortUrl(): Attribute
     {
         return Attribute::make(
             get: fn ($value, $attributes) => url('/'.$attributes['keyword']),

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -109,11 +109,11 @@ class Url extends Model
         return Attribute::make(
             set: function ($value, $attributes) {
                 if (config('urlhub.web_title')) {
-                    return $this->attributes['meta_title'] = $value;
-
                     if (Str::startsWith($value, 'http')) {
                         return $this->attributes['meta_title'] = $this->getWebTitle($value);
                     }
+
+                    return $this->attributes['meta_title'] = $value;
                 }
 
                 return $this->attributes['meta_title'] = 'No Title';

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -91,8 +91,8 @@ class Url extends Model
     protected function userId(): Attribute
     {
         return Attribute::make(
-            set: function ($value, $attributes) {
-                return $attributes['user_id'] = $value === 0 ? self::GUEST_ID : $value;
+            set: function ($value) {
+                return $value === 0 ? self::GUEST_ID : $value;
             },
         );
     }
@@ -100,23 +100,23 @@ class Url extends Model
     protected function longUrl(): Attribute
     {
         return Attribute::make(
-            set: fn ($value, $attributes) => $attributes['long_url'] = rtrim($value, '/'),
+            set: fn ($value) => rtrim($value, '/'),
         );
     }
 
     protected function metaTitle(): Attribute
     {
         return Attribute::make(
-            set: function ($value, $attributes) {
+            set: function ($value) {
                 if (config('urlhub.web_title')) {
                     if (Str::startsWith($value, 'http')) {
-                        return $this->attributes['meta_title'] = $this->getWebTitle($value);
+                        return $this->getWebTitle($value);
                     }
 
-                    return $this->attributes['meta_title'] = $value;
+                    return $value;
                 }
 
-                return $this->attributes['meta_title'] = 'No Title';
+                return 'No Title';
             },
         );
     }

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -74,7 +74,7 @@ class Url extends Model
 
     /*
     |--------------------------------------------------------------------------
-    | Eloquent: Mutators
+    | Accessors & Mutators
     |--------------------------------------------------------------------------
     |
     | Accessors and mutators allow you to format Eloquent attribute values when

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -91,12 +91,11 @@ class Url extends Model
         );
     }
 
-    /**
-     * @return void
-     */
-    public function setLongUrlAttribute(string $value)
+    protected function longUrl(): Attribute
     {
-        $this->attributes['long_url'] = rtrim($value, '/');
+        return Attribute::make(
+            set: fn ($value, $attributes) => $attributes['long_url'] = rtrim($value, '/'),
+        );
     }
 
     /**

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -82,14 +82,13 @@ class Url extends Model
     |
     */
 
-    // Mutator
-
-    /**
-     * @return void
-     */
-    public function setUserIdAttribute(int|null $value)
+    protected function userId(): Attribute
     {
-        $this->attributes['user_id'] = $value === 0 ? self::GUEST_ID : $value;
+        return Attribute::make(
+            set: function ($value, $attributes) {
+                return $attributes['user_id'] = $value === 0 ? self::GUEST_ID : $value;
+            },
+        );
     }
 
     /**

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -6,6 +6,7 @@ use App\Helpers\Helper;
 use App\Http\Requests\StoreUrl;
 use App\Models\Traits\Hashidable;
 use Embed\Embed;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -115,10 +116,11 @@ class Url extends Model
         }
     }
 
-    // Accessor
-    public function getShortUrlAttribute(): string
+    public function shortUrl(): Attribute
     {
-        return url('/'.$this->attributes['keyword']);
+        return Attribute::make(
+            get: fn ($value, $attributes) => url('/'.$attributes['keyword']),
+        );
     }
 
     /*

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,8 +9,3 @@ parameters:
 			message: "#^Parameter \\$set of static method Illuminate\\\\Database\\\\Eloquent\\\\Casts\\\\Attribute\\<mixed,mixed\\>\\:\\:make\\(\\) expects \\(callable\\(mixed, mixed\\=\\)\\: mixed\\)\\|null, Closure\\(mixed, mixed\\)\\: string given\\.$#"
 			count: 1
 			path: app/Models/Url.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: app/Models/Url.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2 +1,16 @@
 parameters:
 	ignoreErrors:
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
+			count: 1
+			path: app/Http/Controllers/UrlController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
+			count: 1
+			path: app/Http/Livewire/Table/AllUlrTable.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
+			count: 1
+			path: app/Http/Livewire/Table/MyUrlTable.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Parameter \\$set of static method Illuminate\\\\Database\\\\Eloquent\\\\Casts\\\\Attribute\\<mixed,mixed\\>\\:\\:make\\(\\) expects \\(callable\\(mixed, mixed\\=\\)\\: mixed\\)\\|null, Closure\\(mixed, mixed\\)\\: mixed given\\.$#"
-			count: 2
-			path: app/Models/Url.php
-
-		-
-			message: "#^Parameter \\$set of static method Illuminate\\\\Database\\\\Eloquent\\\\Casts\\\\Attribute\\<mixed,mixed\\>\\:\\:make\\(\\) expects \\(callable\\(mixed, mixed\\=\\)\\: mixed\\)\\|null, Closure\\(mixed, mixed\\)\\: string given\\.$#"
-			count: 1
-			path: app/Models/Url.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,14 +1,29 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$long_url\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/UrlController.php
+
+		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
 			count: 1
 			path: app/Http/Controllers/UrlController.php
 
 		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$long_url\\.$#"
+			count: 3
+			path: app/Http/Livewire/Table/AllUlrTable.php
+
+		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
 			count: 1
 			path: app/Http/Livewire/Table/AllUlrTable.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$long_url\\.$#"
+			count: 3
+			path: app/Http/Livewire/Table/MyUrlTable.php
 
 		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
@@ -21,6 +36,16 @@ parameters:
 			path: app/Models/Url.php
 
 		-
+			message: "#^Parameter \\$set of static method Illuminate\\\\Database\\\\Eloquent\\\\Casts\\\\Attribute\\<mixed,mixed\\>\\:\\:make\\(\\) expects \\(callable\\(mixed, mixed\\=\\)\\: mixed\\)\\|null, Closure\\(mixed, mixed\\)\\: string given\\.$#"
+			count: 1
+			path: app/Models/Url.php
+
+		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$user_id\\.$#"
 			count: 2
 			path: app/Policies/UrlPolicy.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$long_url\\.$#"
+			count: 1
+			path: app/Services/UrlRedirectionService.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,6 +16,11 @@ parameters:
 			path: app/Http/Livewire/Table/AllUlrTable.php
 
 		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$meta_title\\.$#"
+			count: 2
+			path: app/Http/Livewire/Table/AllUlrTable.php
+
+		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
 			count: 1
 			path: app/Http/Livewire/Table/AllUlrTable.php
@@ -26,17 +31,27 @@ parameters:
 			path: app/Http/Livewire/Table/MyUrlTable.php
 
 		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$meta_title\\.$#"
+			count: 2
+			path: app/Http/Livewire/Table/MyUrlTable.php
+
+		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
 			count: 1
 			path: app/Http/Livewire/Table/MyUrlTable.php
 
 		-
 			message: "#^Parameter \\$set of static method Illuminate\\\\Database\\\\Eloquent\\\\Casts\\\\Attribute\\<mixed,mixed\\>\\:\\:make\\(\\) expects \\(callable\\(mixed, mixed\\=\\)\\: mixed\\)\\|null, Closure\\(mixed, mixed\\)\\: mixed given\\.$#"
-			count: 1
+			count: 2
 			path: app/Models/Url.php
 
 		-
 			message: "#^Parameter \\$set of static method Illuminate\\\\Database\\\\Eloquent\\\\Casts\\\\Attribute\\<mixed,mixed\\>\\:\\:make\\(\\) expects \\(callable\\(mixed, mixed\\=\\)\\: mixed\\)\\|null, Closure\\(mixed, mixed\\)\\: string given\\.$#"
+			count: 1
+			path: app/Models/Url.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/Models/Url.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,46 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$long_url\\.$#"
-			count: 1
-			path: app/Http/Controllers/API/UrlController.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
-			count: 1
-			path: app/Http/Controllers/UrlController.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$long_url\\.$#"
-			count: 3
-			path: app/Http/Livewire/Table/AllUlrTable.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$meta_title\\.$#"
-			count: 2
-			path: app/Http/Livewire/Table/AllUlrTable.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
-			count: 1
-			path: app/Http/Livewire/Table/AllUlrTable.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$long_url\\.$#"
-			count: 3
-			path: app/Http/Livewire/Table/MyUrlTable.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$meta_title\\.$#"
-			count: 2
-			path: app/Http/Livewire/Table/MyUrlTable.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
-			count: 1
-			path: app/Http/Livewire/Table/MyUrlTable.php
-
-		-
 			message: "#^Parameter \\$set of static method Illuminate\\\\Database\\\\Eloquent\\\\Casts\\\\Attribute\\<mixed,mixed\\>\\:\\:make\\(\\) expects \\(callable\\(mixed, mixed\\=\\)\\: mixed\\)\\|null, Closure\\(mixed, mixed\\)\\: mixed given\\.$#"
 			count: 2
 			path: app/Models/Url.php
@@ -54,13 +14,3 @@ parameters:
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/Models/Url.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$user_id\\.$#"
-			count: 2
-			path: app/Policies/UrlPolicy.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$long_url\\.$#"
-			count: 1
-			path: app/Services/UrlRedirectionService.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14,3 +14,13 @@ parameters:
 			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$short_url\\.$#"
 			count: 1
 			path: app/Http/Livewire/Table/MyUrlTable.php
+
+		-
+			message: "#^Parameter \\$set of static method Illuminate\\\\Database\\\\Eloquent\\\\Casts\\\\Attribute\\<mixed,mixed\\>\\:\\:make\\(\\) expects \\(callable\\(mixed, mixed\\=\\)\\: mixed\\)\\|null, Closure\\(mixed, mixed\\)\\: mixed given\\.$#"
+			count: 1
+			path: app/Models/Url.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$user_id\\.$#"
+			count: 2
+			path: app/Policies/UrlPolicy.php


### PR DESCRIPTION
The new way of declarating [accessors and mutators](https://laravel.com/docs/eloquent-mutators) was introduced in Laravel 9

- https://laravel.com/docs/9.x/eloquent-mutators#accessors-and-mutators
- https://benjamincrozat.com/laravel-best-practices#use-the-new-way-of-declaring-accessors-and-mutators