### PR TITLE
require `ext-gmp` to fix exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "keywords": ["laravel", "url-shortener", "shorten-urls", "shorturl"],
     "require": {
         "php": "^8.1",
+        "ext-gmp": "*",
         "blade-ui-kit/blade-icons": "^1.5",
         "doctrine/dbal": "^3.7",
         "embed/embed": "^4.4",


### PR DESCRIPTION
[2023-10-14 20:53:19] production.ERROR: Call to undefined function App\Services\gmp_intval() {"view":{"view":"/www/wwwroot/urlhub/resources/views/backend/about.blade.php","data":[]},"userId":2,"exception":"[object] (Spatie\\LaravelIgnition\\Exceptions\\ViewException(code: 0): Call to undefined function App\\Services\\gmp_intval() at /www/wwwroot/urlhub/app/Services/KeyGeneratorService.php:111)
[stacktrace]
#0 /www/wwwroot/urlhub/resources/views/backend/about.blade.php(49): App\\Services\\KeyGeneratorService->possibleOutput()