### PR TITLE
Fix error data too long for column 'title'

### DIFF
--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -6,7 +6,6 @@ use App\Http\Requests\StoreUrl;
 use App\Services\KeyGeneratorService;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
 
 /**
  * @property int            $id
@@ -122,8 +121,8 @@ class Url extends Model
         return Attribute::make(
             set: function ($value) {
                 if (mb_strlen($value) > self::TITLE_LENGTH) {
-
-                    return Str::limit($value, (self::TITLE_LENGTH - 3), '...');
+                    // $limit minus 3 because Str::limit() adds 3 extra characters.
+                    return str($value)->limit(self::TITLE_LENGTH - 3, '...');
                 }
 
                 return $value;

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -6,6 +6,7 @@ use App\Http\Requests\StoreUrl;
 use App\Services\KeyGeneratorService;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 /**
  * @property int            $id
@@ -30,6 +31,8 @@ class Url extends Model
     const GUEST_ID = null;
 
     const GUEST_NAME = 'Guest';
+
+    const TITLE_LENGTH = 255;
 
     /**
      * The attributes that are mass assignable.
@@ -111,6 +114,20 @@ class Url extends Model
     {
         return Attribute::make(
             set: fn ($value) => rtrim($value, '/'),
+        );
+    }
+
+    protected function title(): Attribute
+    {
+        return Attribute::make(
+            set: function ($value) {
+                if (mb_strlen($value) > self::TITLE_LENGTH) {
+
+                    return Str::limit($value, (self::TITLE_LENGTH - 3), '...');
+                }
+
+                return $value;
+            },
         );
     }
 

--- a/resources/views/frontend/short.blade.php
+++ b/resources/views/frontend/short.blade.php
@@ -5,7 +5,7 @@
     <div class="max-w-7xl mx-auto mb-12">
         <div class="flex flex-wrap mt-6 lg:mt-8 px-4 sm:p-6">
             <div class="md:w-9/12">
-                <div class="text-xl break-words sm:text-2xl lg:text-3xl font-bold mb-4">{!! $url->title !!}</div>
+                <div class="text-xl sm:text-2xl lg:text-3xl font-bold mb-4">{!! $url->title !!}</div>
 
                 <ul class="mb-4">
                     <li class="inline-block pr-4">

--- a/resources/views/frontend/short.blade.php
+++ b/resources/views/frontend/short.blade.php
@@ -5,7 +5,7 @@
     <div class="max-w-7xl mx-auto mb-12">
         <div class="flex flex-wrap mt-6 lg:mt-8 px-4 sm:p-6">
             <div class="md:w-9/12">
-                <div class="text-xl sm:text-2xl lg:text-3xl font-bold mb-4">{!! $url->title !!}</div>
+                <div class="text-xl break-words sm:text-2xl lg:text-3xl font-bold mb-4">{!! $url->title !!}</div>
 
                 <ul class="mb-4">
                     <li class="inline-block pr-4">

--- a/tests/Unit/Models/UrlTest.php
+++ b/tests/Unit/Models/UrlTest.php
@@ -120,6 +120,21 @@ class UrlTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    #[Group('u-model')]
+    public function testSetTitleLength(): void
+    {
+        $lengthLimit = Url::TITLE_LENGTH;
+
+        $url = Url::factory()->create(['title' => str_repeat('a', $lengthLimit)]);
+        $this->assertEquals($lengthLimit, strlen($url->title));
+
+        $url = Url::factory()->create(['title' => str_repeat('a', $lengthLimit - 10)]);
+        $this->assertLessThan($lengthLimit, strlen($url->title));
+
+        $url = Url::factory()->create(['title' => str_repeat('a', $lengthLimit + 10)]);
+        $this->assertEquals($lengthLimit, strlen($url->title));
+    }
+
     #[Test]
     #[Group('u-model')]
     public function setMetaTitleAttributeWhenWebTitleSetToFalse(): void


### PR DESCRIPTION
This PR fixes an error caused by strings that are too long when inserted into the 'title' field.

**Step to reproduce**
1. Shorten any of the links below
   - https://github.com/gitkraken/vscode-gitlens
   - https://github.com/webpack/webpack

<details>
  <summary>Actual</summary>
  
  ![image](https://github.com/realodix/urlhub/assets/1314456/48157c7d-6140-4177-88e9-408c363537e4)
</details>

<details>
  <summary>Expeted</summary>
  
  
  ![image](https://github.com/realodix/urlhub/assets/1314456/44c05f6b-f34c-41e4-b8f5-e0ff822da212)
</details>