### PR TITLE
Show full links for destination links on public pages

### DIFF
--- a/resources/views/frontend/short.blade.php
+++ b/resources/views/frontend/short.blade.php
@@ -63,7 +63,7 @@
                 <div class="break-all max-w-2xl mt-2">
                     @svg('arrow-turn-right')
                     <a href="{{ $url->destination }}" target="_blank" rel="noopener noreferrer" class="redirect-anchor">
-                        {{ urlDisplay($url->destination, limit: 80) }}
+                        {{ $url->destination }}
                     </a>
                 </div>
             </div>

--- a/resources/views/frontend/short.blade.php
+++ b/resources/views/frontend/short.blade.php
@@ -60,11 +60,15 @@
                     </a>
                 </span>
 
-                <div class="break-all max-w-2xl mt-2">
-                    @svg('arrow-turn-right')
-                    <a href="{{ $url->destination }}" target="_blank" rel="noopener noreferrer" class="redirect-anchor">
-                        {{ $url->destination }}
-                    </a>
+                <div class="mt-2">
+                    <div class="flex gap-x-2">
+                        <div class="hidden md:block">@svg('arrow-turn-right')</div>
+                        <div class="break-all max-w-2xl">
+                            <a href="{{ $url->destination }}" target="_blank" rel="noopener noreferrer" class="redirect-anchor">
+                                {{ $url->destination }}
+                            </a>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
It will be easy for someone to know where the link is going.

**Before**
![image](https://github.com/realodix/urlhub/assets/1314456/ad29983a-93d2-48fb-843f-99971cc140ef)

**After**
![image](https://github.com/realodix/urlhub/assets/1314456/c09a7b40-05d6-4999-a76f-70bf86c38357)
