### PR TITLE
Improve the method to get the list of registered routes

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -66,4 +66,17 @@ class Helper
 
         return $url;
     }
+
+    public static function routeList(): array
+    {
+        $route = array_map(
+            fn (\Illuminate\Routing\Route $route) => $route->uri,
+            \Illuminate\Support\Facades\Route::getRoutes()->get()
+        );
+
+        return collect($route)
+            ->map(fn ($value) => preg_replace('/(\/){.+/', '', $value))
+            ->unique()
+            ->toArray();
+    }
 }

--- a/app/Services/KeyGeneratorService.php
+++ b/app/Services/KeyGeneratorService.php
@@ -92,14 +92,9 @@ class KeyGeneratorService
      */
     public function ensureStringCanBeUsedAsKey(string $value): bool
     {
-        $route = array_map(
-            fn (\Illuminate\Routing\Route $route) => $route->uri,
-            \Illuminate\Support\Facades\Route::getRoutes()->get()
-        );
-
         $alreadyInUse = Url::whereKeyword($value)->exists();
         $isReservedKeyword = in_array($value, config('urlhub.reserved_keyword'));
-        $isRoute = in_array($value, $route);
+        $isRoute = in_array($value, \App\Helpers\Helper::routeList());
 
         if ($alreadyInUse || $isReservedKeyword || $isRoute) {
             return false;


### PR DESCRIPTION
- Install `laravel/telescope`, than `telescope` cannot be used as a keyword.
- Install `opcodesio/log-viewer`, than `log-viewer` cannot be used as a keyword.