### PR TITLE
Use a hash function as the basis of a random string

### DIFF
--- a/app/Services/KeyGeneratorService.php
+++ b/app/Services/KeyGeneratorService.php
@@ -17,7 +17,7 @@ class KeyGeneratorService
      */
     public function generate(string $value): string
     {
-        $string = $this->generateSimpleString($value);
+        $string = $this->simpleString($value);
 
         if (
             $this->ensureStringCanBeUsedAsKey($string) === false
@@ -33,7 +33,7 @@ class KeyGeneratorService
         return $string;
     }
 
-    public function generateSimpleString(string $value): string
+    public function simpleString(string $value): string
     {
         return Str::of($value)
             // Delete all characters except those in the ALPHABET constant.

--- a/app/Services/KeyGeneratorService.php
+++ b/app/Services/KeyGeneratorService.php
@@ -3,7 +3,6 @@
 namespace App\Services;
 
 use App\Models\Url;
-use Illuminate\Support\Str;
 
 class KeyGeneratorService
 {
@@ -35,12 +34,7 @@ class KeyGeneratorService
 
     public function simpleString(string $value): string
     {
-        return Str::of($value)
-            // Delete all characters except those in the ALPHABET constant.
-            ->replaceMatches('/[^'.self::ALPHABET.']/i', '')
-            // Take the specified number of characters from the end of the string.
-            ->substr(config('urlhub.keyword_length') * -1)
-            ->lower();
+        return substr(hash('xxh3', $value), 0, config('urlhub.keyword_length'));
     }
 
     /**

--- a/tests/Unit/Services/KeyGeneratorServiceTest.php
+++ b/tests/Unit/Services/KeyGeneratorServiceTest.php
@@ -32,22 +32,6 @@ class KeyGeneratorServiceTest extends TestCase
     }
 
     /**
-     * String dihasilkan dari pemotongan link dari belakang sepanjang panjang
-     * karakter yang telah ditentukan.
-     */
-    #[PHPUnit\Test]
-    public function keyword_test(): void
-    {
-        $length = 3;
-        config(['urlhub.keyword_length' => $length]);
-
-        $longUrl = 'https://github.com/realodix';
-        $urlKey = $this->keyGenerator->generate($longUrl);
-
-        $this->assertSame(substr($longUrl, -$length), $urlKey);
-    }
-
-    /**
      * UrlKey dihasilkan dari hasil pemotongan string URL. Sayangnya terkadang
      * panjang string dari hasil pemotongan tersebut bisa lebih pendek daripada
      * panjang yang harapkan. Ketika itu terjadi, maka generator harus menghasilkan
@@ -88,74 +72,6 @@ class KeyGeneratorServiceTest extends TestCase
 
         $url = Url::whereDestination($longUrl)->first();
         $this->assertTrue($url->is_custom);
-    }
-
-    /**
-     * String yang dihasilkan dari pemotongan tautan harus berupa abjad.
-     */
-    #[PHPUnit\Test]
-    #[PHPUnit\TestWith(['ravel', 'https://github.com/laravel/laravel'])]
-    #[PHPUnit\TestWith(['ravel', 'https://en.wikipedia.org/wiki/Laravel'])]
-    #[PHPUnit\TestWith(['uting', 'https://laravel.com/docs/11.x/routing'])]
-    #[PHPUnit\TestWith(['uting', 'https://en.wikipedia.org/wiki/Routing'])]
-    public function simpleString($expected, $actual): void
-    {
-        config(['urlhub.keyword_length' => 5]);
-
-        $this->assertSame($expected, $this->keyGenerator->simpleString($actual));
-    }
-
-    /**
-     * String yang dihasilkan dari pemotongan tautan harus berupa abjad.
-     */
-    #[PHPUnit\Test]
-    public function generateSimpleString_must_be_alphabet(): void
-    {
-        config(['urlhub.keyword_length' => 3]);
-
-        $this->assertSame('bar', $this->keyGenerator->simpleString('foobar'));
-        $this->assertSame('bar', $this->keyGenerator->simpleString('foob/ar'));
-
-        $this->assertSame('bar', $this->keyGenerator->simpleString('fooBar'));
-    }
-
-    /**
-     * Panjang string yang dihasilkan dari pemotongan link harus harus sesuai
-     * dengan panjang yang telah ditentukan pada konfigurasi.
-     */
-    #[PHPUnit\Test]
-    public function generateSimpleString_string_length(): void
-    {
-        config(['urlhub.keyword_length' => 6]);
-        $actual = 'https://github.com/realodix';
-        $expected = 'alodix';
-        $this->assertSame($expected, $this->keyGenerator->simpleString($actual));
-
-        config(['urlhub.keyword_length' => 9]);
-        $actual = 'https://github.com/realodix';
-        $expected = 'mrealodix';
-        $this->assertSame($expected, $this->keyGenerator->simpleString($actual));
-
-        config(['urlhub.keyword_length' => 12]);
-        $actual = 'https://github.com/realodix';
-        $expected = 'bcomrealodix';
-        $this->assertSame($expected, $this->keyGenerator->simpleString($actual));
-    }
-
-    /**
-     * String yang dihasilkan dari pemotongan link harus berupa huruf kecil.
-     */
-    #[PHPUnit\Test]
-    public function generateSimpleString_mus_be_lowercase(): void
-    {
-        $length = 4;
-        config(['urlhub.keyword_length' => $length]);
-
-        $longUrl = 'https://github.com/realoDIX';
-        $urlKey = $this->keyGenerator->simpleString($longUrl);
-
-        $this->assertSame(mb_strtolower(substr($longUrl, -$length)), $urlKey);
-        $this->assertNotSame(substr($longUrl, -$length), $urlKey);
     }
 
     /**

--- a/tests/Unit/Services/KeyGeneratorServiceTest.php
+++ b/tests/Unit/Services/KeyGeneratorServiceTest.php
@@ -98,11 +98,11 @@ class KeyGeneratorServiceTest extends TestCase
     #[PHPUnit\TestWith(['ravel', 'https://en.wikipedia.org/wiki/Laravel'])]
     #[PHPUnit\TestWith(['uting', 'https://laravel.com/docs/11.x/routing'])]
     #[PHPUnit\TestWith(['uting', 'https://en.wikipedia.org/wiki/Routing'])]
-    public function generateSimpleString($expected, $actual): void
+    public function simpleString($expected, $actual): void
     {
         config(['urlhub.keyword_length' => 5]);
 
-        $this->assertSame($expected, $this->keyGenerator->generateSimpleString($actual));
+        $this->assertSame($expected, $this->keyGenerator->simpleString($actual));
     }
 
     /**
@@ -113,10 +113,10 @@ class KeyGeneratorServiceTest extends TestCase
     {
         config(['urlhub.keyword_length' => 3]);
 
-        $this->assertSame('bar', $this->keyGenerator->generateSimpleString('foobar'));
-        $this->assertSame('bar', $this->keyGenerator->generateSimpleString('foob/ar'));
+        $this->assertSame('bar', $this->keyGenerator->simpleString('foobar'));
+        $this->assertSame('bar', $this->keyGenerator->simpleString('foob/ar'));
 
-        $this->assertSame('bar', $this->keyGenerator->generateSimpleString('fooBar'));
+        $this->assertSame('bar', $this->keyGenerator->simpleString('fooBar'));
     }
 
     /**
@@ -129,17 +129,17 @@ class KeyGeneratorServiceTest extends TestCase
         config(['urlhub.keyword_length' => 6]);
         $actual = 'https://github.com/realodix';
         $expected = 'alodix';
-        $this->assertSame($expected, $this->keyGenerator->generateSimpleString($actual));
+        $this->assertSame($expected, $this->keyGenerator->simpleString($actual));
 
         config(['urlhub.keyword_length' => 9]);
         $actual = 'https://github.com/realodix';
         $expected = 'mrealodix';
-        $this->assertSame($expected, $this->keyGenerator->generateSimpleString($actual));
+        $this->assertSame($expected, $this->keyGenerator->simpleString($actual));
 
         config(['urlhub.keyword_length' => 12]);
         $actual = 'https://github.com/realodix';
         $expected = 'bcomrealodix';
-        $this->assertSame($expected, $this->keyGenerator->generateSimpleString($actual));
+        $this->assertSame($expected, $this->keyGenerator->simpleString($actual));
     }
 
     /**
@@ -152,7 +152,7 @@ class KeyGeneratorServiceTest extends TestCase
         config(['urlhub.keyword_length' => $length]);
 
         $longUrl = 'https://github.com/realoDIX';
-        $urlKey = $this->keyGenerator->generateSimpleString($longUrl);
+        $urlKey = $this->keyGenerator->simpleString($longUrl);
 
         $this->assertSame(mb_strtolower(substr($longUrl, -$length)), $urlKey);
         $this->assertNotSame(substr($longUrl, -$length), $urlKey);


### PR DESCRIPTION
Previous https://github.com/realodix/urlhub/pull/992

The random string generator method is very slow, so the `simpleString` method (30x faster) was created to reduce the use of the random string generator method.

But the method is too simple. Only 2 unique strings can be generated by the `simpleString` method, all others must use the random string generator method.

```php
// Only 2 unique strings

['ravel', 'https://github.com/laravel/laravel'],
['ravel', 'https://stackoverflow.com/questions/tagged/laravel'],
['ravel', 'https://www.youtube.com/hashtag/laravel'],
['ravel', 'https://www.reddit.com/r/laravel/'],
['ravel', 'https://dev.to/t/laravel'],
['ravel', 'https://laracasts.com/topics/laravel'],
['ravel', 'https://laravel.io/forum/tags/laravel'],
['ravel', 'https://medium.com/tag/laravel'],
['ravel', 'https://fontawesome.com/icons/laravel'],

['ravel', 'https://en.wikipedia.org/wiki/Laravel'],
['ravel', 'https://id.wikipedia.org/wiki/Laravel'],

['ework', 'https://github.com/topics/framework'],
['ework', 'https://github.com/laravel/framework'],
['ework', 'https://github.com/codeigniter4/framework'],
['ework', 'https://github.com/spring-projects/spring-framework'],
['ework', 'https://github.com/ionic-team/ionic-framework'],
```

With this PR, we can further reduce the usage of random string generator. 

```php
['2fd03', 'https://github.com/laravel/laravel'],
['bc6c5', 'https://stackoverflow.com/questions/tagged/laravel'],
['9d3cb', 'https://www.youtube.com/hashtag/laravel'],
['048fd', 'https://www.reddit.com/r/laravel/'],
['42ab4', 'https://dev.to/t/laravel'],
['dc009', 'https://laracasts.com/topics/laravel'],
['6cecf', 'https://laravel.io/forum/tags/laravel'],
['4ba17', 'https://medium.com/tag/laravel'],
['09e5d', 'https://fontawesome.com/icons/laravel'],

['7b418', 'https://en.wikipedia.org/wiki/Laravel'],
['59c7d', 'https://id.wikipedia.org/wiki/Laravel'],

['ff45f', 'https://github.com/topics/framework'],
['40b70', 'https://github.com/laravel/framework'],
['be785', 'https://github.com/codeigniter4/framework'],
['0027d', 'https://github.com/spring-projects/spring-framework'],
['eea5d', 'https://github.com/ionic-team/ionic-framework'],
```