### PR TITLE
Improve PowerGrid table [UrlListTable] performance

### DIFF
--- a/app/Livewire/Table/MyUrlTable.php
+++ b/app/Livewire/Table/MyUrlTable.php
@@ -45,21 +45,26 @@ final class MyUrlTable extends PowerGridComponent
     {
         return PowerGrid::fields()
             ->add('keyword', function (Url $url) {
-                return view('components.table.keyword', ['url' => $url])
-                    ->render();
+                return view('components.table.keyword', [
+                    'shortUrl' => $url->short_url,
+                    'keyword' => $url->keyword,
+                ])->render();
             })
             ->add('destination', function (Url $url) {
                 return view('components.table.destination', [
-                    'url' => $url,
+                    'title' => $url->title,
+                    'destination' => $url->destination,
                     'limit' => self::STR_LIMIT,
                 ])->render();
             })
             ->add('t_clicks', function (Url $url) {
-                return view('components.table.visit', ['url' => $url])
-                    ->render();
+                return view('components.table.visit', [
+                    'clicks' => $url->clicks,
+                    'uniqueClicks' => $url->uniqueClicks,
+                ])->render();
             })
             ->add('created_at_formatted', function (Url $url) {
-                return view('components.table.date-created', ['url' => $url])
+                return view('components.table.date-created', ['createdAt' => $url->created_at])
                     ->render();
             })
             ->add('action', function (Url $url) {

--- a/app/Livewire/Table/UrlListOfGuestTable.php
+++ b/app/Livewire/Table/UrlListOfGuestTable.php
@@ -43,21 +43,26 @@ final class UrlListOfGuestTable extends PowerGridComponent
     {
         return PowerGrid::fields()
             ->add('keyword', function (Url $url) {
-                return view('components.table.keyword', ['url' => $url])
-                    ->render();
+                return view('components.table.keyword', [
+                    'shortUrl' => $url->short_url,
+                    'keyword' => $url->keyword,
+                ])->render();
             })
             ->add('destination', function (Url $url) {
                 return view('components.table.destination', [
-                    'url' => $url,
+                    'title' => $url->title,
+                    'destination' => $url->destination,
                     'limit' => MyUrlTable::STR_LIMIT,
                 ])->render();
             })
             ->add('t_clicks', function (Url $url) {
-                return view('components.table.visit', ['url' => $url])
-                    ->render();
+                return view('components.table.visit', [
+                    'clicks' => $url->clicks,
+                    'uniqueClicks' => $url->uniqueClicks,
+                ])->render();
             })
             ->add('created_at_formatted', function (Url $url) {
-                return view('components.table.date-created', ['url' => $url])
+                return view('components.table.date-created', ['createdAt' => $url->created_at])
                     ->render();
             })
             ->add('action', function (Url $url) {

--- a/app/Livewire/Table/UrlListOfUsersTable.php
+++ b/app/Livewire/Table/UrlListOfUsersTable.php
@@ -45,21 +45,26 @@ final class UrlListOfUsersTable extends PowerGridComponent
     {
         return PowerGrid::fields()
             ->add('keyword', function (Url $url) {
-                return view('components.table.keyword', ['url' => $url])
-                    ->render();
+                return view('components.table.keyword', [
+                    'shortUrl' => $url->short_url,
+                    'keyword' => $url->keyword,
+                ])->render();
             })
             ->add('destination', function (Url $url) {
                 return view('components.table.destination', [
-                    'url' => $url,
+                    'title' => $url->title,
+                    'destination' => $url->destination,
                     'limit' => MyUrlTable::STR_LIMIT,
                 ])->render();
             })
             ->add('t_clicks', function (Url $url) {
-                return view('components.table.visit', ['url' => $url])
-                    ->render();
+                return view('components.table.visit', [
+                    'clicks' => $url->clicks,
+                    'uniqueClicks' => $url->uniqueClicks,
+                ])->render();
             })
             ->add('created_at_formatted', function (Url $url) {
-                return view('components.table.date-created', ['url' => $url])
+                return view('components.table.date-created', ['createdAt' => $url->created_at])
                     ->render();
             })
             ->add('action', function (Url $url) {

--- a/app/Livewire/Table/UrlListTable.php
+++ b/app/Livewire/Table/UrlListTable.php
@@ -71,8 +71,10 @@ final class UrlListTable extends PowerGridComponent
                     ->render();
             })
             ->add('keyword', function (Url $url) {
-                return view('components.table.keyword', ['shortUrl' => $url->short_url, 'keyword' => $url->keyword])
-                    ->render();
+                return view('components.table.keyword', [
+                    'shortUrl' => $url->short_url,
+                    'keyword' => $url->keyword,
+                ])->render();
             })
             ->add('destination', function (Url $url) {
                 return view('components.table.destination', [
@@ -82,8 +84,10 @@ final class UrlListTable extends PowerGridComponent
                 ])->render();
             })
             ->add('t_clicks', function (Url $url) {
-                return view('components.table.visit', ['clicks' => $url->visits_count, 'uniqueClicks' => $url->unique_click_count])
-                    ->render();
+                return view('components.table.visit', [
+                    'clicks' => $url->visits_count,
+                    'uniqueClicks' => $url->unique_click_count,
+                ])->render();
             })
             ->add('created_at_formatted', function (Url $url) {
                 return view('components.table.date-created', ['createdAt' => $url->created_at])

--- a/app/Livewire/Table/UrlListTable.php
+++ b/app/Livewire/Table/UrlListTable.php
@@ -6,7 +6,6 @@ use App\Models\Url;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\DB;
-use LaraDumps\LaraDumps\Livewire\Attributes\Ds;
 use PowerComponents\LivewirePowerGrid\Column;
 use PowerComponents\LivewirePowerGrid\Footer;
 use PowerComponents\LivewirePowerGrid\Header;
@@ -17,7 +16,6 @@ use PowerComponents\LivewirePowerGrid\PowerGridFields;
 /**
  * @codeCoverageIgnore
  */
-#[Ds]
 final class UrlListTable extends PowerGridComponent
 {
     const STR_LIMIT = 80;

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -22,6 +22,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string         $short_url
  * @property int            $clicks
  * @property int            $uniqueClicks
+ * @property-read int       $visits_count
+ * @property-read int       $unique_click_count
  */
 class Url extends Model
 {

--- a/resources/views/components/table/author.blade.php
+++ b/resources/views/components/table/author.blade.php
@@ -1,5 +1,5 @@
 <span class="font-semibold">
-    <a href="{{ route('dashboard.allurl.u-user', $url->author->name) }}">
-        {{ $url->author->name }}
+    <a href="{{ route('dashboard.allurl.u-user', $name) }}">
+        {{ $name }}
     </a>
 </span>

--- a/resources/views/components/table/date-created.blade.php
+++ b/resources/views/components/table/date-created.blade.php
@@ -1,5 +1,8 @@
 <div>
-    <span title="{{ $url->created_at->toDayDateTimeString()}} ">
-        {{ $url->created_at->shortRelativeDiffForHumans() }}
+    @php
+        $date = \Illuminate\Support\Carbon::parse($createdAt);
+    @endphp
+    <span title="{{ $date->toDayDateTimeString()}} ">
+        {{ $date->shortRelativeDiffForHumans() }}
     </span>
 </div>

--- a/resources/views/components/table/destination.blade.php
+++ b/resources/views/components/table/destination.blade.php
@@ -2,13 +2,13 @@
 @use('Illuminate\Support\Str')
 
 <div>
-    <span title="{{ $url->title}} ">
-        {{ Str::limit($url->title, $limit) }}
+    <span title="{{ $title}} ">
+        {{ Str::limit($title, $limit) }}
     </span>
 
     <br>
 
-    <a href="{{ $url->destination }}" target="_blank" title="{{ $url->destination }}" rel="noopener noreferrer" class="text-[#6c6c6c]">
-        {{ Helper::urlDisplay($url->destination, $limit) }}
+    <a href="{{ $destination }}" target="_blank" title="{{ $destination }}" rel="noopener noreferrer" class="text-[#6c6c6c]">
+        {{ Helper::urlDisplay($destination, $limit) }}
     </a>
 </div>

--- a/resources/views/components/table/keyword.blade.php
+++ b/resources/views/components/table/keyword.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <a href="{{ $url->short_url }}" title="{{ $url->keyword }}" target="_blank" class="font-light text-sky-800">
-        {{ str()->limit($url->keyword, 12) }}
+    <a href="{{ $shortUrl }}" title="{{ $keyword }}" target="_blank" class="font-light text-sky-800">
+        {{ str()->limit($keyword, 12) }}
     </a>
 </div>

--- a/resources/views/components/table/visit.blade.php
+++ b/resources/views/components/table/visit.blade.php
@@ -1,6 +1,6 @@
 @php
-    $tClick = numberAbbreviate($url->clicks);
-    $uClick = numberAbbreviate($url->uniqueClicks);
+    $tClick = numberAbbreviate($clicks);
+    $uClick = numberAbbreviate($uniqueClicks);
     $title = $tClick.' '.__('Clicks').' / '.$uClick.' '.__('Uniques');
 @endphp
 


### PR DESCRIPTION
This PR improved table performance by reducing unnecessary queries and replacing them with SQL join. This brings a significant performance improvement, as only one query is performed and currently each line executes +- 5 more queries (visit count, is_first_visit).

Currently, if I show 20 records, 120 queries are being performed. In other words, if I show 100 records on the screen, around 600 queries will be performed.

Debug tool: https://github.com/laradumps/laradumps

---

### Before

125 Queries ⇒ 116ms

- LaraDumps Ds Attribute

`Render: 149ms`

![image](https://github.com/realodix/urlhub/assets/33601626/f602ad1e-4a12-4275-9513-9e3030f98386)

- Queries (120 queries)

![image](https://github.com/realodix/urlhub/assets/33601626/9434fca6-0c9f-472a-b7e1-be53596b0bc5)

---

### After

- LaraDumps Ds Attribute

`Render: 21ms`

![image](https://github.com/realodix/urlhub/assets/33601626/48141acc-a15d-4105-8fdc-f0ce14f3e846)

- Queries (2 queries)

![image](https://github.com/realodix/urlhub/assets/33601626/1793aa4d-0f7b-4f61-b451-10454df1095a)

SQL:

```sql
select `urls`.`id` as `id`, `users`.`name` as `author`, `urls`.`title`, `urls`.`keyword`, `urls`.`destination`, `urls`.`created_at`, COUNT(visits.id) as visits_count, SUM(CASE WHEN visits.is_first_click = 1 THEN 1 ELSE 0 END) as unique_click_count from `urls` inner join `users` on `urls`.`user_id` = `users`.`id` left join `visits` on `urls`.`id` = `visits`.`url_id` where `urls`.`user_id` is not null group by `urls`.`id`, `users`.`name`, `urls`.`title`, `urls`.`created_at`, `urls`.`updated_at` order by `keyword` desc limit 25 offset 0
```

Thanks for using [PowerGrid](https://livewire-powergrid.com/)
