### PR TITLE
PowerGrid: Use Eloquent instead Query Builder

### DIFF
--- a/app/Livewire/Table/BaseUrlTable.php
+++ b/app/Livewire/Table/BaseUrlTable.php
@@ -61,7 +61,9 @@ class BaseUrlTable extends PowerGridComponent
     {
         return PowerGrid::fields()
             ->add('author', function (Url $url) {
-                return view('components.table.author', ['name' => $url->author->name])
+                $author = $url->author->name ?? 'Guest';
+
+                return view('components.table.author', ['name' => $author])
                     ->render();
             })
             ->add('keyword', function (Url $url) {

--- a/app/Livewire/Table/BaseUrlTable.php
+++ b/app/Livewire/Table/BaseUrlTable.php
@@ -4,8 +4,6 @@ namespace App\Livewire\Table;
 
 use App\Models\Url;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Query\JoinClause;
-use Illuminate\Support\Facades\DB;
 use PowerComponents\LivewirePowerGrid\Column;
 use PowerComponents\LivewirePowerGrid\Footer;
 use PowerComponents\LivewirePowerGrid\Header;
@@ -47,36 +45,23 @@ class BaseUrlTable extends PowerGridComponent
 
     public function datasource(): Builder
     {
-        return Url::query()
-            ->join('users', 'urls.user_id', '=', 'users.id')
-            ->leftJoinSub(DB::table('visits')
-                ->select('url_id', DB::raw('COUNT(id) as visit_count'))
-                ->groupBy('url_id'), 'visit_counts', function (JoinClause $join) {
-                    $join->on('urls.id', '=', 'visit_counts.url_id');
-                })
-            ->leftJoinSub(DB::table('visits')
-                ->select('url_id', DB::raw('SUM(CASE WHEN is_first_click = 1 THEN 1 ELSE 0 END) as unique_visit_count'))
-                ->groupBy('url_id'), 'unique_visit_counts', function (JoinClause $join) {
-                    $join->on('urls.id', '=', 'unique_visit_counts.url_id');
-                })
-            ->where(fn (Builder $query) => $this->getUserIdBuilder($query))
-            ->select(
-                'urls.id as id',
-                'users.name as author',
-                'urls.title',
-                'urls.keyword',
-                'urls.destination',
-                'urls.created_at',
-                DB::raw('COALESCE(visit_counts.visit_count, 0) as visit_count'),
-                DB::raw('COALESCE(unique_visit_counts.unique_visit_count, 0) as unique_visit_count')
-            );
+        $urls = Url::where(fn (Builder $query) => $this->getUserIdBuilder($query))
+            ->with('author')
+            ->withCount([
+                'visits',
+                'visits as unique_visit_count' => function (Builder $query) {
+                    $query->where('is_first_click', true);
+                },
+            ]);
+
+        return $urls;
     }
 
     public function fields(): PowerGridFields
     {
         return PowerGrid::fields()
             ->add('author', function (Url $url) {
-                return view('components.table.author', ['name' => $url->author])
+                return view('components.table.author', ['name' => $url->author->name])
                     ->render();
             })
             ->add('keyword', function (Url $url) {
@@ -94,7 +79,7 @@ class BaseUrlTable extends PowerGridComponent
             })
             ->add('t_clicks', function (Url $url) {
                 return view('components.table.visit', [
-                    'clicks' => $url->visit_count,
+                    'clicks' => $url->visits_count,
                     'uniqueClicks' => $url->unique_visit_count,
                 ])->render();
             })

--- a/app/Livewire/Table/MyUrlTable.php
+++ b/app/Livewire/Table/MyUrlTable.php
@@ -12,7 +12,7 @@ final class MyUrlTable extends BaseUrlTable
 {
     public function getUserIdBuilder(Builder $query): Builder
     {
-        return $query->where('urls.user_id', '=', auth()->id());
+        return $query->where('urls.user_id', auth()->id());
     }
 
     /**

--- a/app/Livewire/Table/UrlListOfGuestTable.php
+++ b/app/Livewire/Table/UrlListOfGuestTable.php
@@ -13,7 +13,7 @@ final class UrlListOfGuestTable extends BaseUrlTable
 {
     public function getUserIdBuilder(Builder $query): Builder
     {
-        return $query->where('urls.user_id', '=', Url::GUEST_ID);
+        return $query->where('urls.user_id', Url::GUEST_ID);
     }
 
     /**

--- a/app/Livewire/Table/UrlListOfUsersTable.php
+++ b/app/Livewire/Table/UrlListOfUsersTable.php
@@ -14,7 +14,7 @@ final class UrlListOfUsersTable extends BaseUrlTable
 
     public function getUserIdBuilder(Builder $query): Builder
     {
-        return $query->where('urls.user_id', '=', $this->user_id);
+        return $query->where('urls.user_id', $this->user_id);
     }
 
     /**

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -22,7 +22,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property string         $short_url
  * @property int            $clicks
  * @property int            $uniqueClicks
- * @property-read int       $unique_visit_count
  */
 class Url extends Model
 {

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -22,7 +22,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property string         $short_url
  * @property int            $clicks
  * @property int            $uniqueClicks
- * @property-read int       $visit_count
  * @property-read int       $unique_visit_count
  */
 class Url extends Model

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,3 +11,4 @@ parameters:
     ignoreErrors:
         - identifier: missingType.generics
         - identifier: missingType.iterableValue
+        - message: "#Access to an undefined property App\\\\Models\\\\Url\\:\\:\\$unique_visit_count\\.#"


### PR DESCRIPTION
This also fixes `urls.user_id` that contains a `null` value cannot be found.

![image](https://github.com/realodix/urlhub/assets/1314456/42452e74-7dab-4f90-9b3a-cbfb64657fdb)


**Related**:
- https://github.com/realodix/urlhub/pull/1003