### PR TITLE
Refactored user device information generation

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -93,11 +93,17 @@ class User extends Authenticatable
     {
         if (auth()->check() === false) {
             $device = Helper::deviceDetector();
+            $browser = $device->getClient();
+            $os = $device->getOs();
+
+            $browserName = ! empty($browser['name']) ? $browser['name'] : '';
+            $osName = ! empty($os['name']) ? $os['name'] : '';
+            $osVersion = ! empty($os['version']) ? $os['version'] : '';
 
             $userDeviceInfo = implode([
                 'ip'      => request()->ip(),
-                'browser' => $device->getClient('name'),
-                'os'      => $device->getOs('name').$device->getOs('version'),
+                'browser' => $browserName,
+                'os'      => $osName.$osVersion,
                 'device'  => $device->getDeviceName().$device->getModel().$device->getBrandName(),
                 'lang'    => request()->getPreferredLanguage(),
             ]);


### PR DESCRIPTION
This commit refactors the code responsible for generating user device information. Previously, the code directly used device methods within the `implode` function, which could lead to errors if the methods returned arrays.

To address this and improve code readability, temporary variables are introduced to store the results of the device methods (`getClient`, `getOs`). This ensures that string values are used for concatenation within the `userDeviceInfo` array.

These changes enhance code clarity, prevent potential errors, and make the code easier to maintain in the future.