### PR TITLE
Improve the layout of the `Reconfirm Password` page

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -109,5 +109,9 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::confirmPasswordView(function () {
             return view('auth.confirm-password');
         });
+
+        Fortify::confirmPasswordsUsing(function (User $user) {
+            return Hash::check(request('password'), $user->password);
+        });
     }
 }

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -5,35 +5,33 @@
 @section('css_class', 'auth')
 
 @section('content')
-@if ($errors->any())
-    <div>
-        <div>{{ __('Whoops! Something went wrong.') }}</div>
+<div class="flex flex-col min-h-screen sm:justify-center items-center pt-6 sm:pt-0">
+    @if ($errors->any())
+        <div>
+            <div>{{ __('Whoops! Something went wrong.') }}</div>
 
-        <ul>
-            @foreach ($errors->all() as $error)
-                <li>{{ $error }}</li>
-            @endforeach
-        </ul>
-    </div>
-@endif
-
-<form method="POST" action="{{ route('password.confirm') }}">
-@csrf
-    <div>
-        <label>{{ __('Password') }}</label>
-        <input type="password" name="password" autocomplete="current-password" required>
-    </div>
-
-    <div>
-        <button type="submit">
-            {{ __('Confirm Password') }}
-        </button>
-    </div>
-
-    @if (Route::has('password.request'))
-        <a href="{{ route('password.request') }}">
-            {{ __('Forgot Your Password?') }}
-        </a>
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
     @endif
-</form>
+
+    <div class="auth-card">
+        <form method="POST" action="{{ route('password.confirm') }}">
+        @csrf
+            <div>
+                <label>{{ __('Password') }}</label>
+                <input type="password" name="password" autocomplete="current-password" class="form-input" required>
+            </div>
+
+            <div class="flex items-center justify-end mt-4">
+                <button type="submit" class="btn btn-primary ml-4">
+                    {{ __('Confirm Password') }}
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
 @endsection


### PR DESCRIPTION
- https://laravel.com/docs/11.x/authentication#password-confirmation-protecting-routes
- https://github.com/laravel/fortify/blob/79c6b0a9f/src/Fortify.php#L186
- https://github.com/laravel/fortify/blob/79c6b0a9f/src/Fortify.php#L245