### PR TITLE
Prevent normal users from updating other users' urls

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -49,6 +49,8 @@ class DashboardController extends Controller
      */
     public function update(Request $request, Url $url)
     {
+        Gate::authorize('updateUrl', $url);
+
         $request->validate([
             'title'    => ['max:' . Url::TITLE_LENGTH],
             'long_url' => [

--- a/tests/Feature/AuthPage/DashboardPageTest.php
+++ b/tests/Feature/AuthPage/DashboardPageTest.php
@@ -2,9 +2,7 @@
 
 namespace Tests\Feature\AuthPage;
 
-use App\Http\Controllers\Dashboard\DashboardController;
 use App\Models\Url;
-use Illuminate\Http\Request;
 use PHPUnit\Framework\Attributes as PHPUnit;
 use Tests\TestCase;
 

--- a/tests/Feature/AuthPage/DashboardPageTest.php
+++ b/tests/Feature/AuthPage/DashboardPageTest.php
@@ -52,7 +52,6 @@ class DashboardPageTest extends TestCase
     public function dCanUpdateUrl(): void
     {
         $url = Url::factory()->create();
-
         $newLongUrl = 'https://phpunit.readthedocs.io/en/9.1';
 
         $response = $this->actingAs($url->author)
@@ -69,11 +68,33 @@ class DashboardPageTest extends TestCase
         $this->assertSame($newLongUrl, $url->fresh()->destination);
     }
 
+    /**
+     * A normal user can't change the password of another user.
+     */
+    #[PHPUnit\Test]
+    public function normalUserCantUpdateOtherUsersUrl(): void
+    {
+        $url = Url::factory()->create();
+        $newLongUrl = 'https://phpunit.readthedocs.io/en/9.1';
+
+        $response = $this->actingAs($this->basicUser())
+            ->from(route('dboard.url.edit.show', $url->keyword))
+            ->post(route('dboard.url.edit.store', $url->keyword), [
+                'title'    => $url->title,
+                'long_url' => $newLongUrl,
+            ]);
+
+        $response->assertForbidden();
+        $this->assertNotSame($newLongUrl, $url->fresh()->destination);
+    }
+
     public function test_update_validates_title_length(): void
     {
         $request = new Request(['title' => str_repeat('a', Url::TITLE_LENGTH + 1), 'long_url' => 'https://example.com']);
         $this->expectException(\Illuminate\Validation\ValidationException::class);
         (new DashboardController)->update($request, new Url);
+
+        $this->actingAs($user)->post(route('dboard.url.edit.store', $url->keyword), $request);
     }
 
     public function test_update_validates_long_url_is_url(): void

--- a/tests/Feature/AuthPage/DashboardPageTest.php
+++ b/tests/Feature/AuthPage/DashboardPageTest.php
@@ -69,6 +69,10 @@ class DashboardPageTest extends TestCase
 
     /**
      * A normal user can't change the password of another user.
+     *
+     * This test simulates a normal user trying to change the password of another
+     * user, verifies that the operation is forbidden by checking for a forbidden
+     * response, and confirms that the password is unchanged in the database.
      */
     #[PHPUnit\Test]
     public function normalUserCantUpdateOtherUsersUrl(): void


### PR DESCRIPTION
Although the scenario where a regular user updates a url owned by someone else can be a bit tricky, this bug is now completely closed.