### PR TITLE
Perf: Improve keyword generation by reducing random string generation

### DIFF
--- a/app/Services/KeyGeneratorService.php
+++ b/app/Services/KeyGeneratorService.php
@@ -17,17 +17,30 @@ class KeyGeneratorService
      */
     public function generate(string $value): string
     {
-        $string = $this->simpleString($value);
-
-        if (!$this->verify($string) || strlen($string) < config('urlhub.keyword_length')) {
-            do {
-                $randomString = $this->randomString();
-            } while (!$this->verify($randomString));
-
-            return $randomString;
+        $str = $this->simpleString($value);
+        if ($this->verify($str)) {
+            return $str;
         }
 
-        return $string;
+        // If the first attempt fail, try to make the string uppercase
+        $strUpper = strtoupper($str);
+        if ($this->verify($strUpper)) {
+            return $strUpper;
+        }
+
+        // If the second attempt fail, try to add the latest url id
+        $str = $this->simpleString($value . Url::latest('id')->value('id'));
+        if ($this->verify($str)) {
+            return $str;
+        }
+
+        // If the string is still not unique, then generate a random string
+        // until it is unique
+        do {
+            $randomString = $this->randomString();
+        } while (!$this->verify($randomString));
+
+        return $randomString;
     }
 
     public function simpleString(string $value): string

--- a/app/Services/KeyGeneratorService.php
+++ b/app/Services/KeyGeneratorService.php
@@ -28,7 +28,7 @@ class KeyGeneratorService
             return $strUpper;
         }
 
-        // If the second attempt fail, try to add the latest url id
+        // If the second attempt fail, try to append the last url id
         $str = $this->simpleString($value . Url::latest('id')->value('id'));
         if ($this->verify($str)) {
             return $str;

--- a/tests/Unit/Services/KeyGeneratorServiceTest.php
+++ b/tests/Unit/Services/KeyGeneratorServiceTest.php
@@ -33,6 +33,28 @@ class KeyGeneratorServiceTest extends TestCase
     public function testGenerateUniqueString(): void
     {
         $value1 = 'foo';
+
+        $hash = $this->keyGenerator->generate($value1);
+        $this->assertSame($this->keyGenerator->simpleString($value1), $hash);
+
+        $urlFactory = Url::factory()->create(['keyword' => $hash]);
+        $hash2 = $this->keyGenerator->generate($value1);
+        $this->assertSame(strtoupper($this->keyGenerator->simpleString($value1)), $hash2);
+
+        Url::factory()->create(['keyword' => $hash2]);
+        $hash3 = $this->keyGenerator->generate($value1);
+        $this->assertSame(
+            $this->keyGenerator->simpleString($value1 . $urlFactory->latest('id')->value('id')),
+            $hash3
+        );
+
+        Url::factory()->create(['keyword' => $hash3]);
+        $this->assertNotSame($hash2, $this->keyGenerator->generate($value1));
+    }
+
+    public function testGenerateUniqueStringWithReservedKeyword(): void
+    {
+        $value1 = 'foo';
         $generatedString1 = $this->keyGenerator->generate($value1);
         Url::factory()->create(['keyword' => $generatedString1]);
         $this->assertSame($this->keyGenerator->simpleString($value1), $generatedString1);

--- a/tests/Unit/Services/KeyGeneratorServiceTest.php
+++ b/tests/Unit/Services/KeyGeneratorServiceTest.php
@@ -35,16 +35,16 @@ class KeyGeneratorServiceTest extends TestCase
         $value1 = 'foo';
 
         $hash = $this->keyGenerator->generate($value1);
-        $this->assertSame($this->keyGenerator->simpleString($value1), $hash);
+        $this->assertSame($this->keyGenerator->hashedString($value1), $hash);
 
         $urlFactory = Url::factory()->create(['keyword' => $hash]);
         $hash2 = $this->keyGenerator->generate($value1);
-        $this->assertSame(strtoupper($this->keyGenerator->simpleString($value1)), $hash2);
+        $this->assertSame(strtoupper($this->keyGenerator->hashedString($value1)), $hash2);
 
         Url::factory()->create(['keyword' => $hash2]);
         $hash3 = $this->keyGenerator->generate($value1);
         $this->assertSame(
-            $this->keyGenerator->simpleString($value1 . $urlFactory->latest('id')->value('id')),
+            $this->keyGenerator->hashedString($value1 . $urlFactory->latest('id')->value('id')),
             $hash3,
         );
 

--- a/tests/Unit/Services/KeyGeneratorServiceTest.php
+++ b/tests/Unit/Services/KeyGeneratorServiceTest.php
@@ -45,7 +45,7 @@ class KeyGeneratorServiceTest extends TestCase
         $hash3 = $this->keyGenerator->generate($value1);
         $this->assertSame(
             $this->keyGenerator->simpleString($value1 . $urlFactory->latest('id')->value('id')),
-            $hash3
+            $hash3,
         );
 
         Url::factory()->create(['keyword' => $hash3]);


### PR DESCRIPTION
This commit refactors the keyword generation logic to significantly improve performance by minimizing the use of random string generation. The previous implementation relied heavily on a `do...while` loop that repeatedly generated random strings until a valid one was found. This process is computationally expensive, especially under high load.

The new implementation introduces several fallback strategies to avoid random string generation whenever possible:

- Attempts to Hashing the input string directly.
- Tries converting the hashed string to uppercase.
- Append the latest URL ID to the input string and hashes it.

By prioritizing these strategies, the frequency of calling `$this->randomString()` is drastically reduced, leading to a substantial performance improvement.