### PR TITLE
Temporary solution for Vite 6.0.9 issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "autoprefixer": "^10.4.20",
     "laravel-vite-plugin": "^1.1.1",
     "postcss": "^8.4.49",
-    "vite": "^6.0.5"
+    "vite": "6.0.8"
   }
 }


### PR DESCRIPTION
In [Vite v6.0.9](https://github.com/vitejs/vite/blob/v6.0.9/packages/vite/CHANGELOG.md#609-2025-01-20) introduced breaking changes related to a security fixes. This is causing an error with the laravel-vite-plugin (`https://github.com/laravel/vite-plugin/issues/316`). There is a workaround for setting the server config in the vite config file. However, I'm not sure if that's the best/recommended approach yet. Perhaps a fix from laravel-vite-plugin will be released to fix the issue itself.

I have decided to stick with Version 6.0.8 as a temporary solution, until a fix for the `laravel-vite-plugin` is released or another solution is found.