### PR TITLE
Centralize password rules in PasswordRules class

### DIFF
--- a/app/Http/Controllers/Dashboard/User/ChangePasswordController.php
+++ b/app/Http/Controllers/Dashboard/User/ChangePasswordController.php
@@ -41,7 +41,7 @@ class ChangePasswordController extends Controller
         $request->validate([
             'current_password' => ['current_password'],
             'new_password' => [
-                'required', 'min:6', 'confirmed',
+                'required', 'string', ...\App\Rules\PasswordRules::rule(),
                 'unique:users,password', 'different:current_password',
             ],
         ]);

--- a/app/Http/Controllers/Dashboard/User/ChangePasswordController.php
+++ b/app/Http/Controllers/Dashboard/User/ChangePasswordController.php
@@ -41,7 +41,7 @@ class ChangePasswordController extends Controller
         $request->validate([
             'current_password' => ['current_password'],
             'new_password' => [
-                'required', 'string', ...\App\Rules\PasswordRules::rule(),
+                ...\App\Rules\PasswordRules::rule(),
                 'unique:users,password', 'different:current_password',
             ],
         ]);

--- a/app/Rules/PasswordRules.php
+++ b/app/Rules/PasswordRules.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Validation\Rules\Password;
+
+class PasswordRules
+{
+    public static function rule(): array
+    {
+        return [Password::min(5), 'confirmed'];
+    }
+}

--- a/app/Rules/PasswordRules.php
+++ b/app/Rules/PasswordRules.php
@@ -8,6 +8,6 @@ class PasswordRules
 {
     public static function rule(): array
     {
-        return [Password::min(5), 'confirmed'];
+        return ['required', 'string', Password::min(5), 'confirmed'];
     }
 }

--- a/app/Services/Fortify/CreateNewUser.php
+++ b/app/Services/Fortify/CreateNewUser.php
@@ -20,7 +20,7 @@ class CreateNewUser implements CreatesNewUsers
         Validator::make($input, [
             'name'     => ['required', 'string', 'max:50'],
             'email'    => ['required', 'string', 'email', 'max:255', Rule::unique(User::class)],
-            'password' => ['required', 'string', ...\App\Rules\PasswordRules::rule()],
+            'password' => \App\Rules\PasswordRules::rule(),
         ])->validate();
 
         return User::create([

--- a/app/Services/Fortify/CreateNewUser.php
+++ b/app/Services/Fortify/CreateNewUser.php
@@ -3,6 +3,7 @@
 namespace App\Services\Fortify;
 
 use App\Models\User;
+use App\Rules\PasswordRules;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
@@ -20,7 +21,7 @@ class CreateNewUser implements CreatesNewUsers
         Validator::make($input, [
             'name'     => ['required', 'string', 'max:50'],
             'email'    => ['required', 'string', 'email', 'max:255', Rule::unique(User::class)],
-            'password' => \App\Rules\PasswordRules::rule(),
+            'password' => PasswordRules::rule(),
         ])->validate();
 
         return User::create([

--- a/app/Services/Fortify/CreateNewUser.php
+++ b/app/Services/Fortify/CreateNewUser.php
@@ -6,7 +6,6 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
-use Illuminate\Validation\Rules\Password;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 
 class CreateNewUser implements CreatesNewUsers
@@ -21,7 +20,7 @@ class CreateNewUser implements CreatesNewUsers
         Validator::make($input, [
             'name'     => ['required', 'string', 'max:50'],
             'email'    => ['required', 'string', 'email', 'max:255', Rule::unique(User::class)],
-            'password' => ['required', 'string', Password::defaults(), 'confirmed'],
+            'password' => ['required', 'string', ...\App\Rules\PasswordRules::rule()],
         ])->validate();
 
         return User::create([

--- a/app/Services/Fortify/ResetUserPassword.php
+++ b/app/Services/Fortify/ResetUserPassword.php
@@ -17,7 +17,7 @@ class ResetUserPassword implements ResetsUserPasswords
     public function reset(User $user, array $input): void
     {
         Validator::make($input, [
-            'password' => ['required', 'string', 'min:6', 'confirmed'],
+            'password' => ['required', 'string', ...\App\Rules\PasswordRules::rule()],
         ])->validate();
 
         $user->forceFill([

--- a/app/Services/Fortify/ResetUserPassword.php
+++ b/app/Services/Fortify/ResetUserPassword.php
@@ -17,7 +17,7 @@ class ResetUserPassword implements ResetsUserPasswords
     public function reset(User $user, array $input): void
     {
         Validator::make($input, [
-            'password' => ['required', 'string', ...\App\Rules\PasswordRules::rule()],
+            'password' => \App\Rules\PasswordRules::rule(),
         ])->validate();
 
         $user->forceFill([

--- a/app/Services/Fortify/ResetUserPassword.php
+++ b/app/Services/Fortify/ResetUserPassword.php
@@ -3,6 +3,7 @@
 namespace App\Services\Fortify;
 
 use App\Models\User;
+use App\Rules\PasswordRules;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
@@ -17,7 +18,7 @@ class ResetUserPassword implements ResetsUserPasswords
     public function reset(User $user, array $input): void
     {
         Validator::make($input, [
-            'password' => \App\Rules\PasswordRules::rule(),
+            'password' => PasswordRules::rule(),
         ])->validate();
 
         $user->forceFill([


### PR DESCRIPTION
Consolidates all password-related validation rules into a single PasswordRules class located in the `App\Rules` directory. This change improves code maintainability and ensures consistency across the application by providing a single source of truth for password complexity requirements.