### PR TITLE
Move user identification logic to UserService

### DIFF
--- a/app/Http/Controllers/UrlController.php
+++ b/app/Http/Controllers/UrlController.php
@@ -6,9 +6,9 @@ use App\Enums\UserType;
 use App\Http\Middleware\UrlHubLinkChecker;
 use App\Http\Requests\StoreUrlRequest;
 use App\Models\Url;
-use App\Models\User;
 use App\Models\Visit;
 use App\Services\QrCodeService;
+use App\Services\UserService;
 use Illuminate\Routing\Controllers\{HasMiddleware, Middleware};
 use Illuminate\Support\Facades\Gate;
 
@@ -36,7 +36,7 @@ class UrlController extends Controller implements HasMiddleware
             'title'     => app(Url::class)->getWebTitle($request->long_url),
             'keyword'   => app(Url::class)->getKeyword($request),
             'is_custom' => isset($request->custom_key) ? true : false,
-            'user_uid'  => app(User::class)->signature(),
+            'user_uid'  => app(UserService::class)->signature(),
         ]);
 
         return to_route('link_detail', $url->keyword);

--- a/app/Http/Controllers/UrlController.php
+++ b/app/Http/Controllers/UrlController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Enums\UserType;
 use App\Http\Middleware\UrlHubLinkChecker;
 use App\Http\Requests\StoreUrlRequest;
 use App\Models\Url;
@@ -27,16 +26,16 @@ class UrlController extends Controller implements HasMiddleware
      */
     public function create(StoreUrlRequest $request)
     {
-        $userType = auth()->check() ? UserType::User->value : UserType::Guest->value;
+        $userService = app(UserService::class);
 
         $url = Url::create([
             'user_id'   => auth()->id(),
-            'user_type' => $userType,
+            'user_type' => $userService->userType(),
             'destination' => $request->long_url,
             'title'     => app(Url::class)->getWebTitle($request->long_url),
             'keyword'   => app(Url::class)->getKeyword($request),
             'is_custom' => isset($request->custom_key) ? true : false,
-            'user_uid'  => app(UserService::class)->signature(),
+            'user_uid'  => $userService->signature(),
         ]);
 
         return to_route('link_detail', $url->keyword);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,7 +3,6 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
-use App\Helpers\Helper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -83,27 +82,5 @@ class User extends Authenticatable
         return Url::where('user_id', null)
             ->distinct('user_uid')
             ->count();
-    }
-
-    public function signature(): string
-    {
-        if (auth()->check() === false) {
-            $device = Helper::deviceDetector();
-            $browser = $device->getClient();
-            $os = $device->getOs();
-
-            $userDeviceInfo = implode([
-                request()->ip(),
-                $browser['name'] ?? '',
-                $os['name'] ?? '',
-                $os['version'] ?? '',
-                $device->getDeviceName() . $device->getModel() . $device->getBrandName(),
-                request()->getPreferredLanguage(),
-            ]);
-
-            return hash('xxh3', $userDeviceInfo);
-        }
-
-        return (string) auth()->id();
     }
 }

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -7,6 +7,11 @@ use App\Helpers\Helper;
 
 class UserService
 {
+    /**
+     * Generate unique identifiers for users, based on their IP address and more.
+     *
+     * If the user is logged in, the signature is simply the user's ID.
+     */
     public function signature(): string
     {
         if (auth()->check() === false) {

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -39,10 +39,10 @@ class UserService
 
         if (auth()->check() === false) {
             $type = UserType::Guest->value;
-        }
 
-        if ($device->isBot() === true) {
-            $type = UserType::Bot->value;
+            if ($device->isBot() === true) {
+                $type = UserType::Bot->value;
+            }
         }
 
         return $type;

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\UserType;
+use App\Helpers\Helper;
+
+class UserService
+{
+    public function signature(): string
+    {
+        if (auth()->check() === false) {
+            $device = Helper::deviceDetector();
+            $browser = $device->getClient();
+            $os = $device->getOs();
+
+            $userDeviceInfo = implode([
+                request()->ip(),
+                $browser['name'] ?? '',
+                $os['name'] ?? '',
+                $os['version'] ?? '',
+                $device->getDeviceName() . $device->getModel() . $device->getBrandName(),
+                request()->getPreferredLanguage(),
+            ]);
+
+            return hash('xxh3', $userDeviceInfo);
+        }
+
+        return (string) auth()->id();
+    }
+
+    /**
+     * Determine the type of user based on authentication status and device detection.
+     */
+    public function userType(): string
+    {
+        $type = UserType::User->value;
+        $device = Helper::deviceDetector();
+
+        if (auth()->check() === false) {
+            $type = UserType::Guest->value;
+        }
+
+        if ($device->isBot() === true) {
+            $type = UserType::Bot->value;
+        }
+
+        return $type;
+    }
+}

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -9,7 +9,6 @@ class UserService
 {
     /**
      * Generate unique identifiers for users, based on their IP address and more.
-     *
      * If the user is logged in, the signature is simply the user's ID.
      */
     public function signature(): string
@@ -35,7 +34,8 @@ class UserService
     }
 
     /**
-     * Determine the type of user based on authentication status and device detection.
+     * Determine the type of user based on authentication status and device
+     * detection.
      */
     public function userType(): string
     {

--- a/app/Services/VisitorService.php
+++ b/app/Services/VisitorService.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Uri;
 class VisitorService
 {
     public function __construct(
-        protected User $user,
+        protected UserService $userService,
         protected GeneralSettings $settings,
     ) {}
 
@@ -36,7 +36,7 @@ class VisitorService
         Visit::create([
             'url_id'         => $url->id,
             'user_type'      => $this->userType(),
-            'user_uid'       => $this->user->signature(),
+            'user_uid'       => $this->userService->signature(),
             'is_first_click' => $this->isFirstClick($url),
             'referer'        => $this->getRefererHost($referer),
         ]);
@@ -72,7 +72,7 @@ class VisitorService
     public function isFirstClick(Url $url): bool
     {
         $hasVisited = $url->visits()
-            ->where('user_uid', $this->user->signature())
+            ->where('user_uid', $this->userService->signature())
             ->exists();
 
         return $hasVisited ? false : true;

--- a/app/Services/VisitorService.php
+++ b/app/Services/VisitorService.php
@@ -2,10 +2,8 @@
 
 namespace App\Services;
 
-use App\Enums\UserType;
 use App\Helpers\Helper;
 use App\Models\Url;
-use App\Models\User;
 use App\Models\Visit;
 use App\Settings\GeneralSettings;
 use Illuminate\Support\Uri;
@@ -35,32 +33,11 @@ class VisitorService
 
         Visit::create([
             'url_id'         => $url->id,
-            'user_type'      => $this->userType(),
+            'user_type'      => $this->userService->userType(),
             'user_uid'       => $this->userService->signature(),
             'is_first_click' => $this->isFirstClick($url),
             'referer'        => $this->getRefererHost($referer),
         ]);
-    }
-
-    /**
-     * Determine the type of user based on authentication status and device detection.
-     *
-     * @return string The user type, which can be 'user', 'guest', or 'bot'.
-     */
-    public function userType(): string
-    {
-        $type = UserType::User->value;
-        $device = Helper::deviceDetector();
-
-        if (auth()->check() === false) {
-            $type = UserType::Guest->value;
-
-            if ($device->isBot() === true) {
-                $type = UserType::Bot->value;
-            }
-        }
-
-        return $type;
     }
 
     /**

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -40,18 +40,4 @@ class UserTest extends TestCase
         Url::factory()->count(5)->create(['user_id' => Url::GUEST_ID, 'user_uid' => 'foo']);
         $this->assertSame(1, (new User)->totalGuestUsers());
     }
-
-    /**
-     * Test the signature of the user.
-     */
-    public function testSignature(): void
-    {
-        $user = app(User::class);
-        $this->assertTrue(strlen($user->signature()) >= 16);
-
-        $user = $this->basicUser();
-        $this->actingAs($user)
-            ->post(route('link.create'), ['long_url' => 'https://laravel.com']);
-        $this->assertEquals($user->id, $user->signature());
-    }
 }

--- a/tests/Unit/Services/UserServiceTest.php
+++ b/tests/Unit/Services/UserServiceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\UserService;
+use PHPUnit\Framework\Attributes as PHPUnit;
+use Tests\TestCase;
+
+#[PHPUnit\Group('services')]
+class UserServiceTest extends TestCase
+{
+    public function testSignature(): void
+    {
+        $userService = app(UserService::class);
+        $this->assertTrue(strlen($userService->signature()) >= 16);
+
+        $user = $this->basicUser();
+        $this->actingAs($user)
+            ->post(route('link.create'), ['long_url' => 'https://laravel.com']);
+        $this->assertEquals($user->id, $userService->signature());
+    }
+}

--- a/tests/Unit/Services/UserServiceTest.php
+++ b/tests/Unit/Services/UserServiceTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Unit\Services;
 
+use App\Enums\UserType;
+use App\Models\Url;
+use App\Models\Visit;
 use App\Services\UserService;
 use PHPUnit\Framework\Attributes as PHPUnit;
 use Tests\TestCase;
@@ -9,6 +12,8 @@ use Tests\TestCase;
 #[PHPUnit\Group('services')]
 class UserServiceTest extends TestCase
 {
+    const BOT_UA = 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)';
+
     public function testSignature(): void
     {
         $userService = app(UserService::class);
@@ -18,5 +23,71 @@ class UserServiceTest extends TestCase
         $this->actingAs($user)
             ->post(route('link.create'), ['long_url' => 'https://laravel.com']);
         $this->assertEquals($user->id, $userService->signature());
+    }
+
+    public function testUserTypesWhenUserCreateShortLink(): void
+    {
+        $longUrl = 'https://laravel.com';
+
+        $this->actingAs($this->basicUser())
+            ->post(route('link.create'), ['long_url' => $longUrl]);
+
+        $url = Url::where('destination', $longUrl)->first();
+        $this->assertSame(UserType::User, $url->user_type);
+    }
+
+    public function testUserTypesWhenGuestCreateShortLink(): void
+    {
+        $longUrl = 'https://laravel.com';
+
+        $this->post(route('link.create'), ['long_url' => $longUrl]);
+
+        $url = Url::where('destination', $longUrl)->first();
+        $this->assertSame(UserType::Guest, $url->user_type);
+    }
+
+    public function testUserTypesWhenUsertVisit(): void
+    {
+        $url = Url::factory()->create();
+
+        $this->actingAs($this->basicUser())
+            ->get(route('home') . '/' . $url->keyword);
+        $visit = Visit::where('url_id', $url->id)->first();
+        $this->assertSame(UserType::User, $visit->user_type);
+    }
+
+    public function testUserTypesWhenUsertVisitWithBotAgent(): void
+    {
+        $url = Url::factory()->create();
+
+        settings()->fill(['track_bot_visits' => true])->save();
+        $this->actingAs($this->basicUser())
+            ->withHeaders(['user-agent' => self::BOT_UA])
+            ->get(route('home') . '/' . $url->keyword);
+
+        $visit = Visit::where('url_id', $url->id)->first();
+        $this->assertSame(UserType::User, $visit->user_type);
+    }
+
+    public function testUserTypesWhenGuestVisit(): void
+    {
+        $url = Url::factory()->create();
+
+        $this->get(route('home') . '/' . $url->keyword);
+
+        $visit = Visit::where('url_id', $url->id)->first();
+        $this->assertSame(UserType::Guest, $visit->user_type);
+    }
+
+    public function testUserTypesWhenBotVisit(): void
+    {
+        $url = Url::factory()->create();
+
+        settings()->fill(['track_bot_visits' => true])->save();
+        $this->withHeaders(['user-agent' => self::BOT_UA])
+            ->get(route('home') . '/' . $url->keyword);
+
+        $visit = Visit::where('url_id', $url->id)->first();
+        $this->assertSame(UserType::Bot, $visit->user_type);
     }
 }


### PR DESCRIPTION
This PR moves the user signature and type determination logic from the User Model and VisitorService to UserService. This improves code organization and maintainability.