### PR TITLE
Forward query parameters from short link to the destination URL

### DIFF
--- a/app/Http/Controllers/Dashboard/User/UserController.php
+++ b/app/Http/Controllers/Dashboard/User/UserController.php
@@ -53,11 +53,18 @@ class UserController extends Controller implements HasMiddleware
     {
         Gate::authorize('update', $user);
 
-        $request->validate([
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-        ]);
+        $forwardQuery = $request->forward_query ? true : false;
 
-        $user->email = $request->email;
+        if ($user->email == $request->email) {
+            $user->forward_query = $forwardQuery;
+        } else {
+            $request->validate([
+                'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            ]);
+            $user->email = $request->email;
+            $user->forward_query = $forwardQuery;
+        }
+
         $user->save();
 
         return redirect()->back()

--- a/app/Http/Controllers/UrlController.php
+++ b/app/Http/Controllers/UrlController.php
@@ -35,6 +35,7 @@ class UrlController extends Controller implements HasMiddleware
             'title'     => app(Url::class)->getWebTitle($request->long_url),
             'keyword'   => app(Url::class)->getKeyword($request),
             'is_custom' => isset($request->custom_key) ? true : false,
+            'forward_query' => auth()->check() ? true : false,
             'user_uid'  => $userService->signature(),
         ]);
 

--- a/app/Http/Controllers/UrlController.php
+++ b/app/Http/Controllers/UrlController.php
@@ -92,6 +92,7 @@ class UrlController extends Controller implements HasMiddleware
         $url->update([
             'destination' => $request->long_url,
             'title'       => $request->title,
+            'forward_query' => $request->forward_query ? true : false,
         ]);
 
         $flashType = 'flash_success';

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property bool $is_custom
  * @property string $destination
  * @property string $title
+ * @property bool $forward_query
  * @property string $user_uid
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
@@ -48,6 +49,7 @@ class Url extends Model
         'is_custom',
         'destination',
         'title',
+        'forward_query',
         'user_uid',
     ];
 
@@ -60,6 +62,7 @@ class Url extends Model
             'user_id' => 'integer',
             'user_type' => UserType::class,
             'is_custom' => 'boolean',
+            'forward_query' => 'boolean',
         ];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -18,6 +18,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property string $two_factor_secret
  * @property string $two_factor_recovery_codes
  * @property string $remember_token
+ * @property bool $forward_query
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  * @property Url $urls
@@ -34,6 +35,7 @@ class User extends Authenticatable
      */
     protected $fillable = [
         'name', 'email', 'password',
+        'forward_query',
     ];
 
     /**
@@ -50,6 +52,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'forward_query' => 'boolean',
         ];
     }
 

--- a/app/Services/RedirectService.php
+++ b/app/Services/RedirectService.php
@@ -30,6 +30,7 @@ class RedirectService
         $currentQuery = request()->query(); // The `$key` parameter is not filled, so it will return an `array`.
         if (! empty($currentQuery)
             && $settings->forward_query === true
+            && $url->author->forward_query === true
             && $url->forward_query === true
         ) {
             $destinationUrl = $this->resolveQuery($url->destination, $currentQuery);

--- a/app/Services/RedirectService.php
+++ b/app/Services/RedirectService.php
@@ -29,9 +29,9 @@ class RedirectService
         /** @var array $currentQuery */
         $currentQuery = request()->query(); // The `$key` parameter is not filled, so it will return an `array`.
         if (! empty($currentQuery)
-            && $settings->forward_query === true
-            && $url->author->forward_query === true
-            && $url->forward_query === true
+            && $settings->forward_query === true // The `forward_query` setting is enabled on global level
+            && $url->author->forward_query === true // The `forward_query` setting is enabled on author level
+            && $url->forward_query === true // The `forward_query` setting is enabled on URL item level
         ) {
             $destinationUrl = $this->resolveQuery($url->destination, $currentQuery);
         }

--- a/app/Services/RedirectService.php
+++ b/app/Services/RedirectService.php
@@ -28,7 +28,7 @@ class RedirectService
 
         /** @var array $currentQuery */
         $currentQuery = request()->query(); // The `$key` parameter is not filled, so it will return an `array`.
-        if (! empty($currentQuery)) {
+        if (! empty($currentQuery) && $settings->forward_query === true) {
             $destinationUrl = $this->resolveQuery($url->destination, $currentQuery);
         }
 

--- a/app/Services/RedirectService.php
+++ b/app/Services/RedirectService.php
@@ -50,12 +50,6 @@ class RedirectService
      */
     public function resolveQuery($baseUrl, $currentQuery)
     {
-        $uri = Uri::of($baseUrl);
-        $query = $uri->query()
-            ->collect()
-            ->union($currentQuery)
-            ->toArray();
-
-        return $uri->withQuery($query)->__toString();
+        return Uri::of($baseUrl)->withQuery($currentQuery)->__toString();
     }
 }

--- a/app/Services/RedirectService.php
+++ b/app/Services/RedirectService.php
@@ -28,7 +28,10 @@ class RedirectService
 
         /** @var array $currentQuery */
         $currentQuery = request()->query(); // The `$key` parameter is not filled, so it will return an `array`.
-        if (! empty($currentQuery) && $settings->forward_query === true) {
+        if (! empty($currentQuery)
+            && $settings->forward_query === true
+            && $url->forward_query === true
+        ) {
             $destinationUrl = $this->resolveQuery($url->destination, $currentQuery);
         }
 

--- a/app/Services/RedirectService.php
+++ b/app/Services/RedirectService.php
@@ -41,8 +41,8 @@ class RedirectService
 
     /**
      * Resolves a URL by merging query parameters from the current request with
-     * those in the provided base URL. The base URL's parameters are retained
-     * in case of duplicates.
+     * those in the provided base URL. The parameter in the short link will
+     * override its counterpart in the destination URL in case of duplicates.
      *
      * @param string $baseUrl The base URL to which query parameters will be
      *                        appended or merged.

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -18,6 +18,8 @@ class GeneralSettings extends Settings
 
     public bool $retrieve_web_title;
 
+    public bool $forward_query;
+
     public int $redirect_status_code;
 
     public int $redirect_cache_max_age;
@@ -45,6 +47,7 @@ class GeneralSettings extends Settings
             'custom_keyword_min_length' => request()->input('custom_keyword_min_length'),
             'custom_keyword_max_length' => request()->input('custom_keyword_max_length'),
             'retrieve_web_title'        => request()->boolean('retrieve_web_title'),
+            'forward_query'             => request()->boolean('forward_query'),
             'redirect_status_code'      => request()->input('redirect_status_code'),
             'redirect_cache_max_age'    => request()->input('redirect_cache_max_age'),
             'track_bot_visits'          => request()->boolean('track_bot_visits'),

--- a/database/factories/UrlFactory.php
+++ b/database/factories/UrlFactory.php
@@ -26,6 +26,7 @@ class UrlFactory extends Factory
             'destination' => 'https://github.com/realodix/urlhub',
             'title'       => 'No Title',
             'keyword'     => app(KeyGeneratorService::class)->randomString(),
+            'forward_query' => true,
             'is_custom'   => false,
             'user_uid'    => fake()->uuid(),
         ];

--- a/database/factories/UrlFactory.php
+++ b/database/factories/UrlFactory.php
@@ -38,6 +38,7 @@ class UrlFactory extends Factory
             return [
                 'user_id' => Url::GUEST_ID,
                 'user_type' => UserType::Guest,
+                'forward_query' => false,
             ];
         });
     }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password'          => static::$password ??= Hash::make('password'),
             'remember_token'    => Str::random(10),
+            'forward_query'     => true,
         ];
     }
 

--- a/database/migrations/2025_02_14_180023_urls_create_forward_query_column.php
+++ b/database/migrations/2025_02_14_180023_urls_create_forward_query_column.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('urls', function (Blueprint $table) {
+            $table->boolean('forward_query')
+                ->after('title')
+                ->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('urls', function (Blueprint $table) {
+            $table->dropColumn('forward_query');
+        });
+    }
+};

--- a/database/migrations/2025_02_16_160415_users_create_forward_query_column.php
+++ b/database/migrations/2025_02_16_160415_users_create_forward_query_column.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('forward_query')
+                ->after('remember_token')
+                ->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('forward_query');
+        });
+    }
+};

--- a/database/settings/2025_02_14_131216_general_add_forward_query.php
+++ b/database/settings/2025_02_14_131216_general_add_forward_query.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('general.forward_query', true);
+    }
+};

--- a/resources/views/backend/edit.blade.php
+++ b/resources/views/backend/edit.blade.php
@@ -46,9 +46,22 @@
                         <label class="form-label">{{ __('Destination URL') }}</label>
                         <input name="long_url" required placeholder="http://www.my_long_url.com" value="{{ $url->destination }}" class="form-input">
                     </div>
+
+                    @if (settings()->forward_query)
+                        <div class="col-span-6">
+                            <label class="form-label">Forwarding Query Parameters</label>
+                            <p class="font-light text-sm dark:text-dark-400">Enable this to forward query parameters appended to the short URL to the final destination URL. For example, <code class="text-slate-600">https://short.link/abc?id=123</code> will redirect to <code class="text-slate-600">https://example.com?id=123</code>.</p>
+                            <label class="switch float-right mt-6">
+                                <input type="checkbox" name="forward_query" value="1" {{ $url->forward_query ? 'checked' : '' }}>
+                                <span class="slider"></span>
+                            </label>
+                        </div>
+                    @else
+                        <input type="hidden" name="forward_query" value="{{ $url->forward_query ? true : false }}">
+                    @endif
                 </div>
 
-                <div class="flex items-center justify-end mt-4 text-right">
+                <div class="flex items-center justify-end mt-8 text-right">
                     <button type="submit" class="btn btn-primary btn-sm">
                         {{ __('Save Changes') }}
                     </button>

--- a/resources/views/backend/edit.blade.php
+++ b/resources/views/backend/edit.blade.php
@@ -50,7 +50,7 @@
                     @if (settings()->forward_query && $url->author->forward_query)
                         <div class="col-span-6">
                             <label class="form-label">Parameter Passing</label>
-                            <p class="font-light text-sm dark:text-dark-400">Enable this to attach UTM parameters – or any other query parameter – to your short link and they're passed on to the destination URL. For example, <code class="text-slate-600">https://short.link/abc?utm_medium=social</code> will redirect to <code class="text-slate-600">https://example.com?utm_medium=social</code>.</p>
+                            <p class="font-light text-sm dark:text-dark-400">Forward query parameters from your short link to the destination URL. For example, <code class="text-slate-600">https://short.link/abc?utm_medium=social</code> will redirect to <code class="text-slate-600">https://example.com?utm_medium=social</code>.</p>
                             <label class="switch float-right mt-6">
                                 <input type="checkbox" name="forward_query" value="1" {{ $url->forward_query ? 'checked' : '' }}>
                                 <span class="slider"></span>

--- a/resources/views/backend/edit.blade.php
+++ b/resources/views/backend/edit.blade.php
@@ -47,7 +47,7 @@
                         <input name="long_url" required placeholder="http://www.my_long_url.com" value="{{ $url->destination }}" class="form-input">
                     </div>
 
-                    @if (settings()->forward_query)
+                    @if (settings()->forward_query && $url->author->forward_query)
                         <div class="col-span-6">
                             <label class="form-label">Forwarding Query Parameters</label>
                             <p class="font-light text-sm dark:text-dark-400">Enable this to forward query parameters appended to the short URL to the final destination URL. For example, <code class="text-slate-600">https://short.link/abc?id=123</code> will redirect to <code class="text-slate-600">https://example.com?id=123</code>.</p>

--- a/resources/views/backend/edit.blade.php
+++ b/resources/views/backend/edit.blade.php
@@ -49,8 +49,8 @@
 
                     @if (settings()->forward_query && $url->author->forward_query)
                         <div class="col-span-6">
-                            <label class="form-label">Forwarding Query Parameters</label>
-                            <p class="font-light text-sm dark:text-dark-400">Enable this to forward query parameters appended to the short URL to the final destination URL. For example, <code class="text-slate-600">https://short.link/abc?id=123</code> will redirect to <code class="text-slate-600">https://example.com?id=123</code>.</p>
+                            <label class="form-label">Parameter Passing</label>
+                            <p class="font-light text-sm dark:text-dark-400">Enable this to attach UTM parameters – or any other query parameter – to your short link and they're passed on to the destination URL. For example, <code class="text-slate-600">https://short.link/abc?utm_medium=social</code> will redirect to <code class="text-slate-600">https://example.com?utm_medium=social</code>.</p>
                             <label class="switch float-right mt-6">
                                 <input type="checkbox" name="forward_query" value="1" {{ $url->forward_query ? 'checked' : '' }}>
                                 <span class="slider"></span>

--- a/resources/views/backend/settings.blade.php
+++ b/resources/views/backend/settings.blade.php
@@ -67,6 +67,14 @@
                     <h3 class="col-span-6 lg:col-span-5">Redirection</h3>
 
                     <div class="col-span-6 lg:col-span-5">
+                        <label class="form-label">Forwarding Query Parameters</label>
+                        <div class="font-light text-sm dark:text-dark-400">Enable this to forward query parameters appended to the short URL to the final destination URL. For example, <code>https://short.link/abc?id=123</code> will redirect to <code>https://example.com?id=123</code>.</div>
+                        <label class="switch float-right mt-6">
+                            <input type="checkbox" name="forward_query" value="1" {{ $settings->forward_query ? 'checked' : '' }}>
+                            <span class="slider"></span>
+                        </label>
+                    </div>
+                    <div class="col-span-6 lg:col-span-5">
                         <label class="form-label !inline">Redirection Status Code</label>
                         <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections" target="_blank">
                             @svg('icon-help', 'ml-1 hover:scale-110 text-gray-500 dark:text-amber-400')</a>

--- a/resources/views/backend/settings.blade.php
+++ b/resources/views/backend/settings.blade.php
@@ -68,7 +68,7 @@
 
                     <div class="col-span-6 lg:col-span-5">
                         <label class="form-label">Forwarding Query Parameters</label>
-                        <div class="font-light text-sm dark:text-dark-400">Enable this to forward query parameters appended to the short URL to the final destination URL. For example, <code>https://short.link/abc?id=123</code> will redirect to <code>https://example.com?id=123</code>.</div>
+                        <div class="font-light text-sm dark:text-dark-400">Enable this to forward query parameters appended to the short URL to the final destination URL. For example, <code class="text-slate-600">https://short.link/abc?id=123</code> will redirect to <code class="text-slate-600">https://example.com?id=123</code>.</div>
                         <label class="switch float-right mt-6">
                             <input type="checkbox" name="forward_query" value="1" {{ $settings->forward_query ? 'checked' : '' }}>
                             <span class="slider"></span>

--- a/resources/views/backend/settings.blade.php
+++ b/resources/views/backend/settings.blade.php
@@ -67,8 +67,8 @@
                     <h3 class="col-span-6 lg:col-span-5">Redirection</h3>
 
                     <div class="col-span-6 lg:col-span-5">
-                        <label class="form-label">Forwarding Query Parameters</label>
-                        <div class="font-light text-sm dark:text-dark-400">Enable this to forward query parameters appended to the short URL to the final destination URL. For example, <code class="text-slate-600">https://short.link/abc?id=123</code> will redirect to <code class="text-slate-600">https://example.com?id=123</code>.</div>
+                        <label class="form-label">Parameter Passing</label>
+                        <div class="font-light text-sm dark:text-dark-400">Enable this to attach UTM parameters – or any other query parameter – to your short link and they're passed on to the destination URL. For example, <code class="text-slate-600">https://short.link/abc?utm_medium=social</code> will redirect to <code class="text-slate-600">https://example.com?utm_medium=social</code>.</div>
                         <label class="switch float-right mt-6">
                             <input type="checkbox" name="forward_query" value="1" {{ $settings->forward_query ? 'checked' : '' }}>
                             <span class="slider"></span>

--- a/resources/views/backend/settings.blade.php
+++ b/resources/views/backend/settings.blade.php
@@ -68,7 +68,7 @@
 
                     <div class="col-span-6 lg:col-span-5">
                         <label class="form-label">Parameter Passing</label>
-                        <div class="font-light text-sm dark:text-dark-400">Enable this to attach UTM parameters – or any other query parameter – to your short link and they're passed on to the destination URL. For example, <code class="text-slate-600">https://short.link/abc?utm_medium=social</code> will redirect to <code class="text-slate-600">https://example.com?utm_medium=social</code>.</div>
+                        <div class="font-light text-sm dark:text-dark-400">Forward query parameters from your short link to the destination URL. For example, <code class="text-slate-600">https://short.link/abc?utm_medium=social</code> will redirect to <code class="text-slate-600">https://example.com?utm_medium=social</code>.</div>
                         <label class="switch float-right mt-6">
                             <input type="checkbox" name="forward_query" value="1" {{ $settings->forward_query ? 'checked' : '' }}>
                             <span class="slider"></span>

--- a/resources/views/backend/user/account.blade.php
+++ b/resources/views/backend/user/account.blade.php
@@ -31,9 +31,21 @@
                             <label class="form-label">{{ __('E-mail Address') }}</label>
                             <input type="email" name="email" value="{{ $user->email }}" class="form-input mt-1">
                         </div>
+                        @if (settings()->forward_query)
+                            <div class="col-span-6">
+                                <label class="form-label">Forwarding Query Parameters</label>
+                                <p class="font-light text-sm dark:text-dark-400">Enable this to forward query parameters appended to the short URL to the final destination URL. For example, <code class="text-slate-600">https://short.link/abc?id=123</code> will redirect to <code class="text-slate-600">https://example.com?id=123</code>.</p>
+                                <label class="switch float-right mt-6">
+                                    <input type="checkbox" name="forward_query" value="1" {{ $user->forward_query ? 'checked' : '' }}>
+                                    <span class="slider"></span>
+                                </label>
+                            </div>
+                        @else
+                            <input type="hidden" name="forward_query" value="{{ $user->forward_query ? true : false }}">
+                        @endif
                     </div>
 
-                    <div class="flex items-center justify-end mt-4 text-right">
+                    <div class="flex items-center justify-end mt-8 text-right">
                         <button type="submit" class="btn btn-primary btn-sm">
                             {{ __('Save') }}
                         </button>

--- a/resources/views/backend/user/account.blade.php
+++ b/resources/views/backend/user/account.blade.php
@@ -33,8 +33,8 @@
                         </div>
                         @if (settings()->forward_query)
                             <div class="col-span-6">
-                                <label class="form-label">Forwarding Query Parameters</label>
-                                <p class="font-light text-sm dark:text-dark-400">Enable this to forward query parameters appended to the short URL to the final destination URL. For example, <code class="text-slate-600">https://short.link/abc?id=123</code> will redirect to <code class="text-slate-600">https://example.com?id=123</code>.</p>
+                                <label class="form-label">Parameter Passing</label>
+                                <p class="font-light text-sm dark:text-dark-400">Enable this to attach UTM parameters – or any other query parameter – to your short link and they're passed on to the destination URL. For example, <code class="text-slate-600">https://short.link/abc?utm_medium=social</code> will redirect to <code class="text-slate-600">https://example.com?utm_medium=social</code>.</p>
                                 <label class="switch float-right mt-6">
                                     <input type="checkbox" name="forward_query" value="1" {{ $user->forward_query ? 'checked' : '' }}>
                                     <span class="slider"></span>

--- a/resources/views/backend/user/account.blade.php
+++ b/resources/views/backend/user/account.blade.php
@@ -34,7 +34,7 @@
                         @if (settings()->forward_query)
                             <div class="col-span-6">
                                 <label class="form-label">Parameter Passing</label>
-                                <p class="font-light text-sm dark:text-dark-400">Enable this to attach UTM parameters – or any other query parameter – to your short link and they're passed on to the destination URL. For example, <code class="text-slate-600">https://short.link/abc?utm_medium=social</code> will redirect to <code class="text-slate-600">https://example.com?utm_medium=social</code>.</p>
+                                <p class="font-light text-sm dark:text-dark-400">Forward query parameters from your short link to the destination URL. For example, <code class="text-slate-600">https://short.link/abc?utm_medium=social</code> will redirect to <code class="text-slate-600">https://example.com?utm_medium=social</code>.</p>
                                 <label class="switch float-right mt-6">
                                     <input type="checkbox" name="forward_query" value="1" {{ $user->forward_query ? 'checked' : '' }}>
                                     <span class="slider"></span>

--- a/tests/Feature/AuthPage/SettingsPageTest.php
+++ b/tests/Feature/AuthPage/SettingsPageTest.php
@@ -74,6 +74,7 @@ class SettingsPageTest extends TestCase
             'custom_keyword_min_length' => 5,
             'custom_keyword_max_length' => 10,
             'retrieve_web_title' => true,
+            'forward_query' => true,
             'redirect_status_code' => 302,
             'redirect_cache_max_age' => 1,
             'track_bot_visits' => true,

--- a/tests/Feature/FrontPage/ShortenUrl/CreateShortLinkTest.php
+++ b/tests/Feature/FrontPage/ShortenUrl/CreateShortLinkTest.php
@@ -17,6 +17,21 @@ class CreateShortLinkTest extends TestCase
     public function testShortenUrl(): void
     {
         $longUrl = 'https://laravel.com';
+        $response = $this->actingAs($this->basicUser())
+            ->post(route('link.create'), [
+                'long_url' => $longUrl,
+            ]);
+
+        $url = Url::where('destination', $longUrl)->first();
+
+        $response->assertRedirectToRoute('link_detail', $url->keyword);
+        $this->assertFalse($url->is_custom);
+        $this->assertTrue($url->forward_query);
+    }
+
+    public function testGuestCanShortenUrl(): void
+    {
+        $longUrl = 'https://laravel.com';
         $response = $this->post(route('link.create'), [
             'long_url' => $longUrl,
         ]);
@@ -25,6 +40,7 @@ class CreateShortLinkTest extends TestCase
 
         $response->assertRedirectToRoute('link_detail', $url->keyword);
         $this->assertFalse($url->is_custom);
+        $this->assertFalse($url->forward_query);
     }
 
     /**

--- a/tests/Feature/FrontPage/ShortenUrl/CreateShortLinkTest.php
+++ b/tests/Feature/FrontPage/ShortenUrl/CreateShortLinkTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\FrontPage\ShortenUrl;
 use App\Models\Url;
 use App\Services\KeyGeneratorService;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes as PHPUnit;
 use Tests\TestCase;
 
 #[\PHPUnit\Framework\Attributes\Group('front-page')]
@@ -14,6 +15,7 @@ class CreateShortLinkTest extends TestCase
      * Users shorten the URLs, they don't fill in the custom keyword field. The
      * is_custom column (Urls table) must be filled with 0 / false.
      */
+    #[PHPUnit\Group('forward-query')]
     public function testShortenUrl(): void
     {
         $longUrl = 'https://laravel.com';
@@ -29,6 +31,7 @@ class CreateShortLinkTest extends TestCase
         $this->assertTrue($url->forward_query);
     }
 
+    #[PHPUnit\Group('forward-query')]
     public function testGuestCanShortenUrl(): void
     {
         $longUrl = 'https://laravel.com';

--- a/tests/Unit/Controllers/RedirectControllerTest.php
+++ b/tests/Unit/Controllers/RedirectControllerTest.php
@@ -34,6 +34,22 @@ class RedirectControllerTest extends TestCase
 
     /**
      * Visitors are redirected to destinations without source query parameters
+     * if the option is set to false
+     */
+    public function testRedirectWithoutSourceQueryWhenOptionSetToFalse(): void
+    {
+        $url = Url::factory()->create([
+            'destination' => 'https://example.com',
+            'forward_query' => false,
+        ]);
+
+        $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
+        $response->assertRedirect($url->destination)
+            ->assertStatus(settings()->redirect_status_code);
+    }
+
+    /**
+     * Visitors are redirected to destinations without source query parameters
      * if the setting is set to false
      */
     public function testRedirectWithoutSourceQueryWhenSettingSetToFalse(): void
@@ -46,5 +62,9 @@ class RedirectControllerTest extends TestCase
         $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
         $response->assertRedirect($url->destination)
             ->assertStatus($setting->redirect_status_code);
+
+        $response = $this->actingAs($url->author)
+            ->get(route('link.edit', $url->keyword));
+        $response->assertDontSeeText('Forwarding Query');
     }
 }

--- a/tests/Unit/Controllers/RedirectControllerTest.php
+++ b/tests/Unit/Controllers/RedirectControllerTest.php
@@ -26,7 +26,7 @@ class RedirectControllerTest extends TestCase
      */
     public function testRedirectWithSourceQuery(): void
     {
-        $url = Url::factory()->create(['destination' => 'https://example.com']);
+        $url = Url::factory()->create();
 
         $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
         $response->assertRedirect($url->destination . '?a=1&b=2')
@@ -40,10 +40,7 @@ class RedirectControllerTest extends TestCase
     #[PHPUnit\Test]
     public function itDoesntPassQueryParametersWhenForwardQueryIsDisabledOnUrlItem(): void
     {
-        $url = Url::factory()->create([
-            'destination' => 'https://example.com',
-            'forward_query' => false,
-        ]);
+        $url = Url::factory()->create(['forward_query' => false]);
 
         $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
         $response->assertRedirect($url->destination)
@@ -88,7 +85,7 @@ class RedirectControllerTest extends TestCase
         $setting = app(\App\Settings\GeneralSettings::class);
         $setting->fill(['forward_query' => false])->save();
 
-        $url = Url::factory()->create(['destination' => 'https://example.com']);
+        $url = Url::factory()->create();
 
         $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
         $response->assertRedirect($url->destination)

--- a/tests/Unit/Controllers/RedirectControllerTest.php
+++ b/tests/Unit/Controllers/RedirectControllerTest.php
@@ -35,10 +35,10 @@ class RedirectControllerTest extends TestCase
 
     /**
      * It asserts that query parameters are not forwarded to the destination URL
-     * when the 'forward_query' option is explicitly set to false on the URL model.
+     * when the 'forward_query' option is explicitly set to false on the URL item.
      */
     #[PHPUnit\Test]
-    public function itDoesntPassQueryParametersWhenForwardQueryIsDisabledOnUrl(): void
+    public function itDoesntPassQueryParametersWhenForwardQueryIsDisabledOnUrlItem(): void
     {
         $url = Url::factory()->create([
             'destination' => 'https://example.com',
@@ -52,8 +52,35 @@ class RedirectControllerTest extends TestCase
 
     /**
      * It asserts that query parameters are not forwarded to the destination URL
-     * when the global 'forward_query' setting is disabled. It also checks that
-     * the "Forwarding Query" text is not displayed on the edit page.
+     * when the 'forward_query' option is set to false on the URL's author.
+     *
+     * It also checks:
+     * - the "Forwarding Query" text is not displayed on the url edit page.
+     */
+    #[PHPUnit\Test]
+    public function itDoesntPassQueryParametersWhenForwardQueryIsDisabledOnAuthor(): void
+    {
+        $url = Url::factory()
+            // ->for(\App\Models\User::factory()->state(['forward_query' => false]), 'author')
+            ->forAuthor(['forward_query' => false])
+            ->create();
+
+        $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
+        $response->assertRedirect($url->destination)
+            ->assertStatus(settings()->redirect_status_code);
+
+        $response = $this->actingAs($url->author)
+            ->get(route('link.edit', $url->keyword));
+        $response->assertDontSeeText('Forwarding Query');
+    }
+
+    /**
+     * It asserts that query parameters are not forwarded to the destination URL
+     * when the global 'forward_query' setting is disabled.
+     *
+     * It also checks:
+     * - the "Forwarding Query" text is not displayed on the user account edit page.
+     * - the "Forwarding Query" text is not displayed on the url edit page.
      */
     #[PHPUnit\Test]
     public function itDoesntPassQueryParametersWhenForwardQueryIsDisabledGlobally(): void
@@ -66,6 +93,10 @@ class RedirectControllerTest extends TestCase
         $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
         $response->assertRedirect($url->destination)
             ->assertStatus($setting->redirect_status_code);
+
+        $response = $this->actingAs($url->author)
+            ->get(route('user.edit', $url->author));
+        $response->assertDontSeeText('Forwarding Query');
 
         $response = $this->actingAs($url->author)
             ->get(route('link.edit', $url->keyword));

--- a/tests/Unit/Controllers/RedirectControllerTest.php
+++ b/tests/Unit/Controllers/RedirectControllerTest.php
@@ -20,4 +20,34 @@ class RedirectControllerTest extends TestCase
 
         $this->assertCount(1, Visit::all());
     }
+
+    /**
+     * Visitors are redirected to destinations with source query parameters
+     */
+    public function testRedirectWithSourceQuery(): void
+    {
+        $settings = app(\App\Settings\GeneralSettings::class);
+
+        $url = Url::factory()->create(['destination' => 'https://example.com']);
+
+        $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
+        $response->assertRedirect($url->destination . '?a=1&b=2')
+            ->assertStatus($settings->redirect_status_code);
+    }
+
+    /**
+     * Visitors are redirected to destinations without source query parameters
+     * if the setting is set to false
+     */
+    public function testRedirectWithoutSourceQueryWhenSettingSetToFalse(): void
+    {
+        $settings = app(\App\Settings\GeneralSettings::class);
+        $settings->fill(['forward_query' => false])->save();
+
+        $url = Url::factory()->create(['destination' => 'https://example.com']);
+
+        $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
+        $response->assertRedirect($url->destination)
+            ->assertStatus($settings->redirect_status_code);
+    }
 }

--- a/tests/Unit/Controllers/RedirectControllerTest.php
+++ b/tests/Unit/Controllers/RedirectControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Controllers;
 
 use App\Models\Url;
 use App\Models\Visit;
+use PHPUnit\Framework\Attributes as PHPUnit;
 use Tests\TestCase;
 
 #[\PHPUnit\Framework\Attributes\Group('controller')]
@@ -33,10 +34,11 @@ class RedirectControllerTest extends TestCase
     }
 
     /**
-     * Visitors are redirected to destinations without source query parameters
-     * if the option is set to false
+     * It asserts that query parameters are not forwarded to the destination URL
+     * when the 'forward_query' option is explicitly set to false on the URL model.
      */
-    public function testRedirectWithoutSourceQueryWhenOptionSetToFalse(): void
+    #[PHPUnit\Test]
+    public function itDoesntPassQueryParametersWhenForwardQueryIsDisabledOnUrl(): void
     {
         $url = Url::factory()->create([
             'destination' => 'https://example.com',
@@ -49,10 +51,12 @@ class RedirectControllerTest extends TestCase
     }
 
     /**
-     * Visitors are redirected to destinations without source query parameters
-     * if the setting is set to false
+     * It asserts that query parameters are not forwarded to the destination URL
+     * when the global 'forward_query' setting is disabled. It also checks that
+     * the "Forwarding Query" text is not displayed on the edit page.
      */
-    public function testRedirectWithoutSourceQueryWhenSettingSetToFalse(): void
+    #[PHPUnit\Test]
+    public function itDoesntPassQueryParametersWhenForwardQueryIsDisabledGlobally(): void
     {
         $setting = app(\App\Settings\GeneralSettings::class);
         $setting->fill(['forward_query' => false])->save();

--- a/tests/Unit/Controllers/RedirectControllerTest.php
+++ b/tests/Unit/Controllers/RedirectControllerTest.php
@@ -24,6 +24,7 @@ class RedirectControllerTest extends TestCase
     /**
      * Visitors are redirected to destinations with source query parameters
      */
+    #[PHPUnit\Group('forward-query')]
     public function testRedirectWithSourceQuery(): void
     {
         $url = Url::factory()->create();
@@ -38,6 +39,7 @@ class RedirectControllerTest extends TestCase
      * when the 'forward_query' option is explicitly set to false on the URL item.
      */
     #[PHPUnit\Test]
+    #[PHPUnit\Group('forward-query')]
     public function itDoesntPassQueryParametersWhenForwardQueryIsDisabledOnUrlItem(): void
     {
         $url = Url::factory()->create(['forward_query' => false]);
@@ -55,6 +57,7 @@ class RedirectControllerTest extends TestCase
      * - the "Forwarding Query" text is not displayed on the url edit page.
      */
     #[PHPUnit\Test]
+    #[PHPUnit\Group('forward-query')]
     public function itDoesntPassQueryParametersWhenForwardQueryIsDisabledOnAuthor(): void
     {
         $url = Url::factory()
@@ -80,6 +83,7 @@ class RedirectControllerTest extends TestCase
      * - the "Forwarding Query" text is not displayed on the url edit page.
      */
     #[PHPUnit\Test]
+    #[PHPUnit\Group('forward-query')]
     public function itDoesntPassQueryParametersWhenForwardQueryIsDisabledGlobally(): void
     {
         $setting = app(\App\Settings\GeneralSettings::class);

--- a/tests/Unit/Controllers/RedirectControllerTest.php
+++ b/tests/Unit/Controllers/RedirectControllerTest.php
@@ -12,11 +12,10 @@ class RedirectControllerTest extends TestCase
     public function testUrlRedirection(): void
     {
         $url = Url::factory()->create();
-        $settings = app(\App\Settings\GeneralSettings::class);
 
         $response = $this->get(route('home') . '/' . $url->keyword);
         $response->assertRedirect($url->destination)
-            ->assertStatus($settings->redirect_status_code);
+            ->assertStatus(settings()->redirect_status_code);
 
         $this->assertCount(1, Visit::all());
     }
@@ -26,13 +25,11 @@ class RedirectControllerTest extends TestCase
      */
     public function testRedirectWithSourceQuery(): void
     {
-        $settings = app(\App\Settings\GeneralSettings::class);
-
         $url = Url::factory()->create(['destination' => 'https://example.com']);
 
         $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
         $response->assertRedirect($url->destination . '?a=1&b=2')
-            ->assertStatus($settings->redirect_status_code);
+            ->assertStatus(settings()->redirect_status_code);
     }
 
     /**
@@ -41,13 +38,13 @@ class RedirectControllerTest extends TestCase
      */
     public function testRedirectWithoutSourceQueryWhenSettingSetToFalse(): void
     {
-        $settings = app(\App\Settings\GeneralSettings::class);
-        $settings->fill(['forward_query' => false])->save();
+        $setting = app(\App\Settings\GeneralSettings::class);
+        $setting->fill(['forward_query' => false])->save();
 
         $url = Url::factory()->create(['destination' => 'https://example.com']);
 
         $response = $this->get(route('home') . '/' . $url->keyword . '?a=1&b=2');
         $response->assertRedirect($url->destination)
-            ->assertStatus($settings->redirect_status_code);
+            ->assertStatus($setting->redirect_status_code);
     }
 }

--- a/tests/Unit/Services/RedirectServiceTest.php
+++ b/tests/Unit/Services/RedirectServiceTest.php
@@ -64,7 +64,9 @@ class RedirectServiceTest extends TestCase
     }
 
     /**
-     * https://dub.co/help/article/parameter-passing
+     * Reference:
+     * - https://dub.co/help/article/parameter-passing
+     * - https://help.short.io/en/articles/8880292
      */
     public static function urlWithDuplicateQueryStringDataProvider(): array
     {

--- a/tests/Unit/Services/RedirectServiceTest.php
+++ b/tests/Unit/Services/RedirectServiceTest.php
@@ -46,17 +46,37 @@ class RedirectServiceTest extends TestCase
             'existing_and_new_query_params' => [
                 'https://example.com?x=y', ['a' => '1', 'b' => '2'], 'https://example.com?x=y&a=1&b=2',
             ],
-            'duplicate_params' => [
-                'https://example.com?a=1', ['a' => '2'], 'https://example.com?a=1',
-            ],
-            'duplicate_params_and_new_query_params' => [
-                'https://example.com?a=1', ['a' => '2', 'b' => '2'], 'https://example.com?a=1&b=2',
-            ],
             'fragment' => [
                 'https://example.com#section', ['a' => '1'], 'https://example.com?a=1#section',
             ],
             'special_chars' => [ // space encoding
                 'https://example.com?a=b c', ['d' => 'e'], 'https://example.com?a=b%20c&d=e',
+            ],
+        ];
+    }
+
+    #[PHPUnit\DataProvider('urlWithDuplicateQueryStringDataProvider')]
+    public function testUrlWithDuplicateQueryString(string $destination, array $incomingQuery, string $expectedDestination): void
+    {
+        $query = app(RedirectService::class)->resolveQuery($destination, $incomingQuery);
+
+        $this->assertSame($expectedDestination, $query);
+    }
+
+    /**
+     * https://dub.co/help/article/parameter-passing
+     */
+    public static function urlWithDuplicateQueryStringDataProvider(): array
+    {
+        return [
+            'duplicate_params' => [
+                'https://example.com?a=1', ['a' => '2'], 'https://example.com?a=2',
+            ],
+            'duplicate_params_and_new_query_params' => [
+                'https://example.com?a=1', ['a' => '2', 'b' => '2'], 'https://example.com?a=2&b=2',
+            ],
+            'duplicate_params_and_existing_duplicate_query_params' => [
+                'https://example.com?a=1&a=2', ['a' => '2', 'b' => 'b1', 'b' => 'b2'], 'https://example.com?a=2&b=b2',
             ],
         ];
     }

--- a/tests/Unit/Services/RedirectServiceTest.php
+++ b/tests/Unit/Services/RedirectServiceTest.php
@@ -23,6 +23,7 @@ class RedirectServiceTest extends TestCase
         $this->assertEquals(settings()->redirect_status_code, $response->status());
     }
 
+    #[PHPUnit\Group('forward-query')]
     #[PHPUnit\DataProvider('urlWithQueryStringDataProvider')]
     public function testUrlWithQueryString(string $destination, array $incomingQuery, string $expectedDestination): void
     {
@@ -55,6 +56,7 @@ class RedirectServiceTest extends TestCase
         ];
     }
 
+    #[PHPUnit\Group('forward-query')]
     #[PHPUnit\DataProvider('urlWithDuplicateQueryStringDataProvider')]
     public function testUrlWithDuplicateQueryString(string $destination, array $incomingQuery, string $expectedDestination): void
     {

--- a/tests/Unit/Services/RedirectServiceTest.php
+++ b/tests/Unit/Services/RedirectServiceTest.php
@@ -7,13 +7,13 @@ use App\Services\RedirectService;
 use PHPUnit\Framework\Attributes as PHPUnit;
 use Tests\TestCase;
 
+/**
+ * @see \App\Services\RedirectService
+ * @see \App\Http\Controllers\RedirectController
+ */
 #[PHPUnit\Group('services')]
 class RedirectServiceTest extends TestCase
 {
-    /**
-     * @see \App\Services\RedirectService
-     * @see \App\Http\Controllers\RedirectController
-     */
     public function testUrlRedirect()
     {
         $url = Url::factory()->create();
@@ -23,10 +23,44 @@ class RedirectServiceTest extends TestCase
         $this->assertEquals(settings()->redirect_status_code, $response->status());
     }
 
-    /**
-     * @see \App\Services\RedirectService
-     * @see \App\Http\Controllers\RedirectController
-     */
+    #[PHPUnit\DataProvider('urlWithQueryStringDataProvider')]
+    public function testUrlWithQueryString(string $destination, array $incomingQuery, string $expectedDestination): void
+    {
+        $query = app(RedirectService::class)->resolveQuery($destination, $incomingQuery);
+
+        $this->assertSame($expectedDestination, $query);
+    }
+
+    public static function urlWithQueryStringDataProvider(): array
+    {
+        return [
+            'new_query_param' => [
+                'https://example.com', ['a' => '1'], 'https://example.com?a=1',
+            ],
+            'new_query_params' => [
+                'https://example.com', ['a' => '1', 'b' => '2'], 'https://example.com?a=1&b=2',
+            ],
+            'existing_query_params' => [
+                'https://example.com?a=1', ['a' => '1'], 'https://example.com?a=1',
+            ],
+            'existing_and_new_query_params' => [
+                'https://example.com?x=y', ['a' => '1', 'b' => '2'], 'https://example.com?x=y&a=1&b=2',
+            ],
+            'duplicate_params' => [
+                'https://example.com?a=1', ['a' => '2'], 'https://example.com?a=1',
+            ],
+            'duplicate_params_and_new_query_params' => [
+                'https://example.com?a=1', ['a' => '2', 'b' => '2'], 'https://example.com?a=1&b=2',
+            ],
+            'fragment' => [
+                'https://example.com#section', ['a' => '1'], 'https://example.com?a=1#section',
+            ],
+            'special_chars' => [ // space encoding
+                'https://example.com?a=b c', ['d' => 'e'], 'https://example.com?a=b%20c&d=e',
+            ],
+        ];
+    }
+
     public function testUrlRedirectionHeadersWithMaxAge()
     {
         settings()->fill(['redirect_cache_max_age' => 3600])->save();
@@ -37,10 +71,6 @@ class RedirectServiceTest extends TestCase
         $this->assertStringContainsString('max-age=3600', $response->headers->get('Cache-Control'));
     }
 
-    /**
-     * @see \App\Services\RedirectService
-     * @see \App\Http\Controllers\RedirectController
-     */
     public function testUrlRedirectionHeadersWithMaxAgeZero()
     {
         settings()->fill(['redirect_cache_max_age' => 0])->save();


### PR DESCRIPTION
With parameter passing, you can attach UTM parameters – or any other query parameter – to your short link and they're passed on to the destination URL.

For example, you can pass a `utm_source` parameter with the value website to a short link like `urlhub.test/passthrough` and they're passed on to the destination URL.

| Short link | Destination URL | 
| ---------- | --------------- | 
| urlhub.test/passthrough | example.com/pass-url-parameters?ref=x.com | 
| urlhub.test/passthrough?utm_source=website | example.com/pass-url-parameters?ref=x.com&utm_source=website |

If there are any duplicate parameters, the parameter in the short link will override its counterpart in the destination URL:

| Short link | Destination URL |
| ---------- | --------------- | 
| urlhub.test/passthrough | example.com/pass-url-parameters?ref=x.com |
| urlhub.test/passthrough?ref=t.co | example.com/pass-url-parameters?ref=t.co |

In the example above, the `ref` parameter in the short link will override the `ref` parameter in the destination URL.

This is particularly helpful when you're posting the same short link across multiple social media channels and want to quickly customize the UTM parameters for each channel without having to create a new short link for each one.

Reference:
- https://github.com/realodix/urlhub/issues/1072
- https://help.short.io/en/articles/8880292
- https://dub.co/help/article/parameter-passing