### PR TITLE
Remove redundant password hashing

### DIFF
--- a/app/Http/Controllers/Dashboard/User/ChangePasswordController.php
+++ b/app/Http/Controllers/Dashboard/User/ChangePasswordController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Dashboard\User;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\{Gate, Hash};
+use Illuminate\Support\Facades\Gate;
 
 class ChangePasswordController extends Controller
 {
@@ -50,10 +50,10 @@ class ChangePasswordController extends Controller
         // Check if admin user is changing another user's password.
         // Admin authority check has been done by the gate.
         if (!auth()->user()->is($user)) {
-            $user->password = Hash::make($newPassword);
+            $user->password = $newPassword;
             $user->save();
         } else {
-            $request->user()->password = Hash::make($newPassword);
+            $request->user()->password = $newPassword;
             $request->user()->save();
 
             // Clear sessions on other devices

--- a/app/Http/Controllers/Dashboard/User/UserController.php
+++ b/app/Http/Controllers/Dashboard/User/UserController.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controllers\{HasMiddleware, Middleware};
-use Illuminate\Support\Facades\{Gate, Hash};
+use Illuminate\Support\Facades\Gate;
 
 class UserController extends Controller implements HasMiddleware
 {
@@ -52,7 +52,7 @@ class UserController extends Controller implements HasMiddleware
         $user = User::create([
             'name' => $request->username,
             'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'password' => $request->password,
         ]);
 
         if ($request->role == 'admin') {

--- a/app/Services/Fortify/CreateNewUser.php
+++ b/app/Services/Fortify/CreateNewUser.php
@@ -4,7 +4,6 @@ namespace App\Services\Fortify;
 
 use App\Models\User;
 use App\Rules\UserRules;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 
@@ -26,7 +25,7 @@ class CreateNewUser implements CreatesNewUsers
         return User::create([
             'name'     => $input['name'],
             'email'    => $input['email'],
-            'password' => Hash::make($input['password']),
+            'password' => $input['password'],
         ]);
     }
 }

--- a/app/Services/Fortify/ResetUserPassword.php
+++ b/app/Services/Fortify/ResetUserPassword.php
@@ -4,7 +4,6 @@ namespace App\Services\Fortify;
 
 use App\Models\User;
 use App\Rules\UserRules;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
@@ -22,7 +21,7 @@ class ResetUserPassword implements ResetsUserPasswords
         ])->validate();
 
         $user->forceFill([
-            'password' => Hash::make($input['password']),
+            'password' => $input['password'],
         ])->save();
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -4,7 +4,6 @@ namespace Database\Seeders;
 
 use App\Models\User;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\Hash;
 
 class UserSeeder extends Seeder
 {
@@ -16,13 +15,13 @@ class UserSeeder extends Seeder
         User::factory()->create([
             'name'       => 'admin',
             'email'      => 'admin@urlhub.test',
-            'password'   => Hash::make('admin'),
+            'password'   => 'admin',
         ])->assignRole('admin');
 
         User::factory()->create([
             'name'       => 'user',
             'email'      => 'user@urlhub.test',
-            'password'   => Hash::make('user'),
+            'password'   => 'user',
         ]);
     }
 }

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
-use Illuminate\Support\Facades\Hash;
 use PHPUnit\Framework\Attributes as PHPUnit;
 use Tests\TestCase;
 
@@ -62,7 +61,7 @@ class LoginTest extends TestCase
     public function userCanLoginWithCorrectCredentials(): void
     {
         $user = User::factory()->create([
-            'password' => Hash::make($password = 'i-love-laravel'),
+            'password' => $password = 'i-love-laravel',
         ]);
 
         $response = $this->post($this->postRoute(), [
@@ -80,13 +79,9 @@ class LoginTest extends TestCase
     #[PHPUnit\Test]
     public function userCannotLoginWithIncorrectPassword(): void
     {
-        $user = User::factory()->create([
-            'password' => Hash::make('i-love-laravel'),
-        ]);
-
         $response = $this->from($this->getRoute())
             ->post($this->postRoute(), [
-                'identity' => $user->email,
+                'identity' => $this->basicUser()->email,
                 'password' => 'invalid-password',
             ]);
 

--- a/tests/Feature/AuthPage/User/ChangePasswordTest.php
+++ b/tests/Feature/AuthPage/User/ChangePasswordTest.php
@@ -92,13 +92,13 @@ class ChangePasswordTest extends TestCase
                 'new_password_confirmation' => 'new-awesome-password',
             ]);
 
-        $response
-            ->assertRedirect($this->getRoute($this->user->name))
-            ->assertSessionHas('flash_success');
-
         $this->assertTrue(
             Hash::check('new-awesome-password', $this->user->fresh()->password),
         );
+
+        $response
+            ->assertRedirect($this->getRoute($this->user->name))
+            ->assertSessionHas('flash_success');
     }
 
     /**
@@ -121,13 +121,13 @@ class ChangePasswordTest extends TestCase
                 'new_password_confirmation' => 'new-awesome-password',
             ]);
 
-        $response
-            ->assertRedirect($this->getRoute($this->user->name))
-            ->assertSessionHas('flash_success');
-
         $this->assertTrue(
             Hash::check('new-awesome-password', $this->user->fresh()->password),
         );
+
+        $response
+            ->assertRedirect($this->getRoute($this->user->name))
+            ->assertSessionHas('flash_success');
     }
 
     /**

--- a/tests/Feature/AuthPage/User/ChangePasswordTest.php
+++ b/tests/Feature/AuthPage/User/ChangePasswordTest.php
@@ -20,7 +20,7 @@ class ChangePasswordTest extends TestCase
         parent::setUp();
 
         $this->user = User::factory()->create([
-            'password' => bcrypt(self::$password),
+            'password' => self::$password,
         ]);
     }
 


### PR DESCRIPTION
Due to implementing the `hashed` cast in the `User` model ([app/Models/User.php#L56](https://github.com/realodix/urlhub/blob/614e49fcdde46452480229fc4873af7cf2100fb0/app/Models/User.php#L56)), the manual `Hash::make()` and `bcrypt()` calls are no longer needed.

**Changes include:**
- Removed `Hash::make()` and replaced it with a
  plain string.
- Removed `bcrypt()` and replaced it with a plain string.

**Reference:**
- https://github.com/realodix/urlhub/blob/614e49fcdde46452480229fc4873af7cf2100fb0/app/Models/User.php#L56
- https://github.com/laravel/laravel/commit/7e0a2db2e072436dd00a4fa129aebffb3c08d877
- https://laravel.com/docs/12.x/eloquent-mutators#attribute-casting