### PR TITLE
reducing policy code duplication

### DIFF
--- a/app/Http/Controllers/Dashboard/User/ChangePasswordController.php
+++ b/app/Http/Controllers/Dashboard/User/ChangePasswordController.php
@@ -19,7 +19,7 @@ class ChangePasswordController extends Controller
      */
     public function view(User $user)
     {
-        Gate::authorize('view', $user);
+        Gate::authorize('authorOrAdmin', $user);
 
         return view('backend.user.changepassword', ['user' => $user]);
     }
@@ -35,7 +35,7 @@ class ChangePasswordController extends Controller
      */
     public function update(Request $request, User $user)
     {
-        Gate::authorize('updatePass', $user);
+        Gate::authorize('authorOrAdmin', $user);
 
         $request->validate([
             'current_password' => ['current_password'],

--- a/app/Http/Controllers/Dashboard/User/UserController.php
+++ b/app/Http/Controllers/Dashboard/User/UserController.php
@@ -72,7 +72,7 @@ class UserController extends Controller implements HasMiddleware
      */
     public function edit(User $user)
     {
-        Gate::authorize('view', $user);
+        Gate::authorize('authorOrAdmin', $user);
 
         $tzList = app(\Realodix\Timezone\Timezone::class)
             ->toSelectBox('user_timezone', $user->timezone, [
@@ -96,7 +96,7 @@ class UserController extends Controller implements HasMiddleware
      */
     public function update(Request $request, User $user)
     {
-        Gate::authorize('update', $user);
+        Gate::authorize('authorOrAdmin', $user);
 
         $data = [
             'forward_query' => $request->forward_query ? true : false,

--- a/app/Http/Controllers/LinkPasswordController.php
+++ b/app/Http/Controllers/LinkPasswordController.php
@@ -16,7 +16,7 @@ class LinkPasswordController extends Controller
      */
     public function create(Url $url)
     {
-        Gate::authorize('view', $url);
+        Gate::authorize('authorOrAdmin', $url);
 
         return view('backend.linkpassword.create', ['url' => $url]);
     }
@@ -46,7 +46,7 @@ class LinkPasswordController extends Controller
      */
     public function edit(Url $url)
     {
-        Gate::authorize('view', $url);
+        Gate::authorize('authorOrAdmin', $url);
 
         return view('backend.linkpassword.edit', ['url' => $url]);
     }

--- a/app/Http/Controllers/UrlController.php
+++ b/app/Http/Controllers/UrlController.php
@@ -72,7 +72,7 @@ class UrlController extends Controller implements HasMiddleware
      */
     public function edit(Url $url)
     {
-        Gate::authorize('updateUrl', $url);
+        Gate::authorize('authorOrAdmin', $url);
 
         $data = [
             'url' => $url,
@@ -94,7 +94,7 @@ class UrlController extends Controller implements HasMiddleware
      */
     public function update(StoreUrlRequest $request, Url $url)
     {
-        Gate::authorize('updateUrl', $url);
+        Gate::authorize('authorOrAdmin', $url);
 
         $request->validate([
             'title' => ['max:'.Url::TITLE_LENGTH],
@@ -125,7 +125,7 @@ class UrlController extends Controller implements HasMiddleware
      */
     public function delete(Url $url)
     {
-        Gate::authorize('forceDelete', $url);
+        Gate::authorize('authorOrAdmin', $url);
 
         $url->delete();
 

--- a/app/Policies/UrlPolicy.php
+++ b/app/Policies/UrlPolicy.php
@@ -11,25 +11,9 @@ class UrlPolicy
     use HandlesAuthorization;
 
     /**
-     * Determine whether the user can permanently delete the url.
+     * Determine if the given user is the owner URL or is an administrator.
      */
-    public function view(User $user, Url $url): bool
-    {
-        return $user->hasRole('admin') || $user->id === $url->user_id;
-    }
-
-    /**
-     * Determine whether the user can permanently delete the url.
-     */
-    public function forceDelete(User $user, Url $url): bool
-    {
-        return $user->hasRole('admin') || $user->id === $url->user_id;
-    }
-
-    /**
-     * Determine whether the user can update the url.
-     */
-    public function updateUrl(User $user, Url $url): bool
+    public function authorOrAdmin(User $user, Url $url): bool
     {
         return $user->hasRole('admin') || $user->id === $url->user_id;
     }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -9,17 +9,10 @@ class UserPolicy
 {
     use HandlesAuthorization;
 
-    public function view(User $authUser, User $user): bool
-    {
-        return $authUser->hasRole('admin') || $authUser->id === $user->id;
-    }
-
-    public function update(User $authUser, User $user): bool
-    {
-        return $authUser->hasRole('admin') || $authUser->id === $user->id;
-    }
-
-    public function updatePass(User $authUser, User $user): bool
+    /**
+     * Determine if the given user is the owner URL or is an administrator.
+     */
+    public function authorOrAdmin(User $authUser, User $user): bool
     {
         return $authUser->hasRole('admin') || $authUser->id === $user->id;
     }

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -9,75 +9,33 @@ use Tests\TestCase;
 #[PHPUnit\Group('policy')]
 class UserPolicyTest extends TestCase
 {
-    /**
-     * Admin can access their own the page and other user pages.
-     */
     #[PHPUnit\Test]
-    public function viewAsAdmin(): void
+    public function authorOrAdmin(): void
     {
+        // Admin can manage all data.
         $admin = $this->adminUser();
+        $this->assertTrue($admin->can('authorOrAdmin', $admin));
+        $this->assertTrue($admin->can('authorOrAdmin', new User));
 
-        $this->assertTrue($admin->can('view', $admin));
-        $this->assertTrue($admin->can('view', new User));
+        // Normal users can only manage their own data.
+        $owner = $this->basicUser();
+        $this->assertTrue($owner->can('authorOrAdmin', $owner));
+
+        // Normal users cant manage other users data.
+        $this->assertFalse($owner->can('authorOrAdmin', new User));
     }
 
-    /**
-     * Non-admin can only access their own page.
-     */
     #[PHPUnit\Test]
-    public function viewAsBasicUser(): void
+    public function forceDelete(): void
     {
-        $user = $this->basicUser();
-
-        $this->assertTrue($user->can('view', $user));
-        $this->assertFalse($user->can('view', new User));
-    }
-
-    /**
-     * Admin can change their own data and other user data.
-     */
-    #[PHPUnit\Test]
-    public function updateAsAdmin(): void
-    {
+        // Admin cant delete their own data, but can delete other users data.
         $admin = $this->adminUser();
+        $this->assertTrue($admin->can('forceDelete', new User));
+        $this->assertFalse($admin->can('forceDelete', $admin));
 
-        $this->assertTrue($admin->can('update', $admin));
-        $this->assertTrue($admin->can('update', new User));
-    }
-
-    /**
-     * Non-admin can only change their own data.
-     */
-    #[PHPUnit\Test]
-    public function updateAsBasicUser(): void
-    {
-        $user = $this->basicUser();
-
-        $this->assertTrue($user->can('update', $user));
-        $this->assertFalse($user->can('update', new User));
-    }
-
-    /**
-     * Admin can change their own data and other user data.
-     */
-    #[PHPUnit\Test]
-    public function updatePassAsAdmin(): void
-    {
-        $admin = $this->adminUser();
-
-        $this->assertTrue($admin->can('updatePass', $admin));
-        $this->assertTrue($admin->can('updatePass', new User));
-    }
-
-    /**
-     * Non-admin can only change their own data.
-     */
-    #[PHPUnit\Test]
-    public function updatePassAsBasicUser(): void
-    {
-        $user = $this->basicUser();
-
-        $this->assertTrue($user->can('updatePass', $user));
-        $this->assertFalse($user->can('updatePass', new User));
+        // Normal users cant delete their own data or other users data.
+        $owner = $this->basicUser();
+        $this->assertFalse($owner->can('forceDelete', $owner));
+        $this->assertFalse($owner->can('forceDelete', new User));
     }
 }


### PR DESCRIPTION
This commit streamlines the authorization policies, including UrlPolicy, by consolidating redundant checks into a single `authorOrAdmin` method. 

This reduces code duplication and improves readability. Similar refactoring has been applied to other policy classes to maintain consistency and efficiency.