### PR TITLE
feat: Allow uppercase characters in custom keywords

### DIFF
--- a/app/Providers/MacroServiceProvider.php
+++ b/app/Providers/MacroServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 
 class MacroServiceProvider extends ServiceProvider
@@ -26,5 +27,14 @@ class MacroServiceProvider extends ServiceProvider
 
             return self::this()->copy()->tz($userTimezone);
         });
+
+        // A SQLite UDF for the REGEXP keyword that mimics the behavior in MySQL.
+        if (DB::connection() instanceof \Illuminate\Database\SQLiteConnection) {
+            DB::connection()->getPdo()->sqliteCreateFunction('REGEXP', function (string $pattern, string $value) {
+                mb_regex_encoding('UTF-8');
+
+                return mb_ereg($pattern, $value) !== false ? 1 : 0;
+            });
+        }
     }
 }

--- a/app/Rules/LinkRules.php
+++ b/app/Rules/LinkRules.php
@@ -33,7 +33,7 @@ class LinkRules
 
         return [
             new AlphaNumDash,
-            "min:{$minLen}", "max:{$maxLen}", 'lowercase:field',
+            "min:{$minLen}", "max:{$maxLen}",
             'unique:App\Models\Url,keyword',
             new NotBlacklistedKeyword,
         ];

--- a/app/Services/KeyGeneratorService.php
+++ b/app/Services/KeyGeneratorService.php
@@ -81,10 +81,13 @@ class KeyGeneratorService
      */
     public function verify(string $keyword): bool
     {
-        $keywordExists = Url::where('keyword', $keyword)->exists();
+        $keyExists = Url::where('keyword', $keyword)
+            ->where('is_custom', false)->exists();
+        $customKeyExists = Url::whereRaw('LOWER(keyword) = ?', [strtolower($keyword)])
+            ->where('is_custom', true)->exists();
         $keyIsReserved = $this->reservedKeyword()->contains(strtolower($keyword));
 
-        if ($keywordExists || $keyIsReserved) {
+        if ($keyExists || $customKeyExists || $keyIsReserved) {
             return false;
         }
 

--- a/app/Services/KeyGeneratorService.php
+++ b/app/Services/KeyGeneratorService.php
@@ -174,9 +174,7 @@ class KeyGeneratorService
     */
 
     /**
-     * The maximum number of unique random keywords that can be generated based on
-     * the current character length configuration, minus weighted value for reserved
-     * keywords.
+     * Calculate the maximum number of unique random strings that can be generated.
      */
     public function capacity(): int
     {
@@ -184,32 +182,59 @@ class KeyGeneratorService
     }
 
     /**
-     * Calculate the number of unique random strings that can still be generated.
+     * Calculate the remaining capacity for generating new random strings.
      */
     public function remainingCapacity(): int
     {
         // max() is used to avoid negative values
-        return max($this->capacity() - $this->keywordCount(), 0);
+        return max($this->capacity() - $this->totalKeywordSpaceUsed(), 0);
     }
 
     /**
-     * Counts the number of valid keywords, where the keywords have a length equal
-     * to the configured keyword length and contain only allowed characters.
+     * Calculates the total occupancy within the available keyspace.
      */
-    public function keywordCount(): int
+    public function totalKeywordSpaceUsed(): int
+    {
+        return $this->standardKeywordSpaceUsed() + $this->customKeywordSpaceUsed();
+    }
+
+    /**
+     * Calculates the keyspace used by standard keywords, based on the current
+     * character length configuration.
+     */
+    public function standardKeywordSpaceUsed(): int
     {
         $length = $this->settings->key_len;
 
-        return Url::whereRaw('LENGTH(keyword) = ?', [$length])
-            ->when(\Illuminate\Support\Facades\DB::getDriverName() === 'sqlite',
-                function (\Illuminate\Database\Eloquent\Builder $query): void {
-                    $query->whereRaw("keyword NOT LIKE ? ESCAPE '\'", ['%\_%']);
-                },
-                function (\Illuminate\Database\Eloquent\Builder $query): void {
-                    $query->whereNotLike('keyword', '%\\_%');
-                },
-            )
+        return Url::where('is_custom', false)
+            ->whereRaw('LENGTH(keyword) = ?', [$length])
             ->count();
+    }
+
+    /**
+     * Calculates the amount of keyspace used by custom keywords based on their
+     * composition and the current character length configuration. Custom keywords
+     * use more space within the total capacity than their simple count suggests
+     * due to the generator potentially needing to avoid case variants.
+     */
+    public function customKeywordSpaceUsed(): int
+    {
+        $length = $this->settings->key_len;
+
+        // Evaluate by categorizing them into several types:
+        $regular = Url::where('is_custom', true)
+            ->composition('alpha', $length)
+            ->count() * pow(2, $length);
+        $numOrSymbol = Url::where('is_custom', true)
+            ->composition('has_num_or_symbol', $length)
+            ->count() * pow(2, $length - 1);
+        $numAndSymbol = Url::where('is_custom', true)
+            ->composition('has_num_and_symbol', $length)
+            ->count() * pow(2, $length - 2);
+        $onlyNumSymbol = Url::where('is_custom', true)
+            ->composition('only_num_symbol', $length)->count();
+
+        return $regular + $numOrSymbol + $numAndSymbol + $onlyNumSymbol;
     }
 
     /**

--- a/resources/views/backend/overview.blade.php
+++ b/resources/views/backend/overview.blade.php
@@ -114,7 +114,9 @@
         </x-tabs>
 
         <h3 class="text-xl">Random String</h3>
-        <p class="font-light text-sm dark:text-dark-400">Capacity is the estimated maximum number of random strings that can be generated to create short links. The generator will reject when the randomly generated string reaches the maximum limit of the capacity.</p>
+        <p class="font-light text-sm dark:text-dark-400">
+            <strong>Capacity</strong> is the maximum number of unique random keywords that can be generated, minus the weighted value for the space used by the reserved keywords. <strong>Keyword Space Used</strong> indicating how much of the total capacity has been filled. The closer this number gets to the capacity, the fewer new random combinations remain available. Note: based on the current character length configuration.
+        </p>
         <div class="mt-4 mb-6 px-0">
             <dl class="grid grid-cols-1 md:grid-flow-col md:auto-cols-auto gap-2.5 sm:gap-3">
                 <div class="card !bg-gray-50 dark:!bg-dark-950/50 !rounded px-4 py-2">
@@ -122,19 +124,15 @@
                         Capacity
                     </dt>
                     <dd class="-mt-1 font-normal text-gray-900 dark:text-emerald-500 md:mt-1">
-                        @if ($keyGenService->maxUniqueStrings() === PHP_INT_MAX)
-                            (<code>PHP_INT_MAX</code>) {{ number_format(PHP_INT_MAX) }}
-                        @else
-                            {{ number_format($keyGenService->capacity()) }}
-                        @endif
+                        {{ number_format($keyGenService->capacity()) }}
                     </dd>
                 </div>
                 <div class="card !bg-gray-50 dark:!bg-dark-950/50 !rounded px-4 py-2">
                     <dt class="text-sm font-medium text-gray-600 dark:text-dark-300 md:mt-1 md:w-64">
-                        Generated
+                        Keyword Space Used
                     </dt>
                     <dd class="-mt-1 font-normal text-gray-900 dark:text-emerald-500 md:mt-1 md:w-64">
-                        {{ number_format($keyGenService->keywordCount()) }}
+                        {{ number_format($keyGenService->totalKeywordSpaceUsed()) }}
                     </dd>
                 </div>
             </dl>

--- a/tests/Feature/Config/AboutPageTest.php
+++ b/tests/Feature/Config/AboutPageTest.php
@@ -231,8 +231,8 @@ class AboutPageTest extends TestCase
     */
 
     #[PHPUnit\Test]
-    public function keywordCount(): void
+    public function standardKeywordSpaceUsed(): void
     {
-        $this->assertSame(self::KEYWORD_COUNT, $this->keyGen->keywordCount());
+        $this->assertSame(self::KEYWORD_COUNT, $this->keyGen->standardKeywordSpaceUsed());
     }
 }

--- a/tests/Unit/Services/KeyGeneratorServiceTest.php
+++ b/tests/Unit/Services/KeyGeneratorServiceTest.php
@@ -11,25 +11,15 @@ use Tests\TestCase;
 #[PHPUnit\Group('services')]
 class KeyGeneratorServiceTest extends TestCase
 {
-    private const N_URL_WITH_USER_ID = 1;
-    private const N_URL_WITHOUT_USER_ID = 2;
     private const RESOURCE_PREFIX = 'zzz';
 
-    private Url $url;
-
     private KeyGeneratorService $keyGen;
-
-    private int $totalUrl;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->url = new Url;
-
         $this->keyGen = app(KeyGeneratorService::class);
-
-        $this->totalUrl = self::N_URL_WITH_USER_ID + self::N_URL_WITHOUT_USER_ID;
     }
 
     public function testGenerateUniqueString(): void
@@ -84,7 +74,7 @@ class KeyGeneratorServiceTest extends TestCase
      * The `verify` function should return `false` when the string is already
      * used as a short link keyword
      */
-    public function testStringIsAlreadyUsedAsAShortLinkKeyword(): void
+    public function testStringIsAlreadyInUse(): void
     {
         $value = $this->keyGen->generate('https://github.com/realodix');
 
@@ -205,53 +195,58 @@ class KeyGeneratorServiceTest extends TestCase
         );
     }
 
-    /**
-     * Pengujian dilakukan berdasarkan panjang karakternya.
-     */
-    public function testKeywordCountBasedOnStringLength(): void
+    #[PHPUnit\Test]
+    public function totalKeywordSpaceUsed(): void
     {
-        $keywordLength = 5;
-        settings()->fill(['key_len' => $keywordLength])->save();
+        $keyLen = 3;
 
-        Url::factory()->create([
-            'keyword' => $this->keyGen->randomString(),
-        ]);
-        $this->assertSame(1, $this->keyGen->keywordCount());
+        settings()->fill(['key_len' => $keyLen])->save();
+        Url::factory()->create(['keyword' => 'foo', 'is_custom' => false]); // 1
+        Url::factory()->create(['keyword' => 'bar', 'is_custom' => true]); // 8
+        $this->assertSame(9, $this->keyGen->totalKeywordSpaceUsed());
 
-        Url::factory()->create([
-            'keyword' => str_repeat('a', $keywordLength),
-            'is_custom' => true,
-        ]);
-        $this->assertSame(2, $this->keyGen->keywordCount());
-
-        // 'keyword' length is not match with 'key_len', so it is not counted.
-        Url::factory()->create([
-            'keyword' => str_repeat('b', $keywordLength + 2),
-            'is_custom' => true,
-        ]);
-        $this->assertSame(2, $this->keyGen->keywordCount());
-
-        settings()->fill(['key_len' => $keywordLength + 3])->save();
-        $this->assertSame(0, $this->keyGen->keywordCount());
-        $this->assertSame($this->totalUrl, $this->url->count());
+        // Character length does not meet criteria
+        settings()->fill(['key_len' => $keyLen + 1])->save();
+        $this->assertSame(0, $this->keyGen->totalKeywordSpaceUsed());
+        settings()->fill(['key_len' => $keyLen - 1])->save();
+        $this->assertSame(0, $this->keyGen->totalKeywordSpaceUsed());
     }
 
-    /**
-     * Only alphanumeric characters.
-     */
-    public function testKeywordCountBasedOnStringCharacters(): void
+    #[PHPUnit\Test]
+    public function standardKeywordSpaceUsed(): void
     {
-        settings()->fill(['key_len' => 3])->save();
+        $keyLen = 3;
 
-        Url::factory()->count(5)->sequence(
-            ['keyword' => 'abc'],
-            ['keyword' => 'foo'],
-            ['keyword' => 'f1_'],
-            ['keyword' => '_12'],
-            ['keyword' => 'f_2'],
-        )->create();
+        settings()->fill(['key_len' => $keyLen])->save();
+        Url::factory()->create(['keyword' => 'foo', 'is_custom' => false]);
+        Url::factory()->create(['keyword' => 'bar', 'is_custom' => false]);
+        $this->assertSame(2, $this->keyGen->standardKeywordSpaceUsed());
 
-        $this->assertSame(2, $this->keyGen->keywordCount());
+        // Character length does not meet criteria
+        settings()->fill(['key_len' => $keyLen + 1])->save();
+        $this->assertSame(0, $this->keyGen->standardKeywordSpaceUsed());
+        settings()->fill(['key_len' => $keyLen - 1])->save();
+        $this->assertSame(0, $this->keyGen->standardKeywordSpaceUsed());
+    }
+
+    #[PHPUnit\Test]
+    public function customKeywordSpaceUsed(): void
+    {
+        $keyLen = 3;
+
+        settings()->fill(['key_len' => $keyLen])->save();
+        Url::factory()->create(['keyword' => 'abc', 'is_custom' => true]); // 8
+        Url::factory()->create(['keyword' => 'a2c', 'is_custom' => true]); // 4
+        Url::factory()->create(['keyword' => 'a-c', 'is_custom' => true]); // 4
+        Url::factory()->create(['keyword' => 'a2-', 'is_custom' => true]); // 2
+        Url::factory()->create(['keyword' => '-12', 'is_custom' => true]); // 1
+        $this->assertSame(19, $this->keyGen->customKeywordSpaceUsed());
+
+        // Character length does not meet criteria
+        settings()->fill(['key_len' => $keyLen + 1])->save();
+        $this->assertSame(0, $this->keyGen->customKeywordSpaceUsed());
+        settings()->fill(['key_len' => $keyLen - 1])->save();
+        $this->assertSame(0, $this->keyGen->customKeywordSpaceUsed());
     }
 
     #[PHPUnit\Test]
@@ -265,7 +260,7 @@ class KeyGeneratorServiceTest extends TestCase
         $mock = $this->partialMock(KeyGeneratorService::class);
         $mock->shouldReceive([
             'capacity' => $capacity,
-            'keywordCount' => $used,
+            'totalKeywordSpaceUsed' => $used,
         ]);
         $actual = $mock->remainingCapacity();
 

--- a/tests/Unit/Services/KeyGeneratorServiceTest.php
+++ b/tests/Unit/Services/KeyGeneratorServiceTest.php
@@ -76,11 +76,17 @@ class KeyGeneratorServiceTest extends TestCase
      */
     public function testStringIsAlreadyInUse(): void
     {
-        $value = $this->keyGen->generate('https://github.com/realodix');
+        $standardKey = 'fOo';
+        Url::factory()->create(['keyword' => $standardKey, 'is_custom' => false]);
+        $this->assertFalse($this->keyGen->verify($standardKey));
+        $this->assertTrue($this->keyGen->verify(strtoupper($standardKey)));
+        $this->assertTrue($this->keyGen->verify(strtolower($standardKey)));
 
-        Url::factory()->create(['keyword' => $value]);
-
-        $this->assertFalse($this->keyGen->verify($value));
+        $customeKey = 'bAr';
+        Url::factory()->create(['keyword' => $customeKey, 'is_custom' => true]);
+        $this->assertFalse($this->keyGen->verify($customeKey));
+        $this->assertFalse($this->keyGen->verify(strtoupper($customeKey)));
+        $this->assertFalse($this->keyGen->verify(strtolower($customeKey)));
     }
 
     /**


### PR DESCRIPTION
This allows users to create short links using custom keywords that contain uppercase letters, in addition to lowercase letters, numbers, and dashes.