### PR TITLE
Prevent duplicate queries in visit chart by caching data

### DIFF
--- a/app/Livewire/Chart/BaseLinkVisitChart.php
+++ b/app/Livewire/Chart/BaseLinkVisitChart.php
@@ -67,8 +67,10 @@ abstract class BaseLinkVisitChart extends ChartWidget
      */
     protected function getPeriodData(CarbonPeriod $period)
     {
-        // Check if the data is already cached to avoid querying the database
-        // multiple times. Once for total visits and once for unique visitors.
+        // The `getData()` calls this function via `chartData()` twice per render:
+        // "total visits" and "unique visitors". We cache the query result in
+        // `$this->visitsData` on the first run to ensure the database is only
+        // hit once per request, preventing duplicate queries.
         if ($this->visitsData === null) {
             $this->visitsData = Visit::query()
                 ->when($this->model instanceof User, function ($query) {

--- a/app/Livewire/Chart/BaseLinkVisitChart.php
+++ b/app/Livewire/Chart/BaseLinkVisitChart.php
@@ -8,6 +8,7 @@ use App\Models\Visit;
 use Carbon\CarbonPeriod;
 use Filament\Support\Colors\Color;
 use Filament\Widgets\ChartWidget;
+use Illuminate\Database\Eloquent\Collection;
 
 /**
  * @codeCoverageIgnore
@@ -19,6 +20,11 @@ abstract class BaseLinkVisitChart extends ChartWidget
     protected static ?string $pollingInterval = null;
 
     public User|Url|null $model = null;
+
+    /**
+     * @var Collection<int,\App\Models\Visit>|null
+     */
+    private ?Collection $visitsData = null;
 
     /** {@inheritdoc} */
     protected function getType(): string
@@ -57,18 +63,24 @@ abstract class BaseLinkVisitChart extends ChartWidget
     /**
      * Return the visits data for the given period.
      *
-     * @return \Illuminate\Database\Eloquent\Collection<int, \App\Models\Visit>
+     * @return \Illuminate\Database\Eloquent\Collection<int,\App\Models\Visit>
      */
     protected function getPeriodData(CarbonPeriod $period)
     {
-        return Visit::query()
-            ->when($this->model instanceof User, function ($query) {
-                $query->whereRelation('url', 'user_id', $this->model->id);
-            })
-            ->when($this->model instanceof Url, function ($query) {
-                $query->where('url_id', $this->model->id);
-            })
-            ->whereBetween('created_at', [$period->getStartDate(), $period->getEndDate()])
-            ->get(['user_uid', 'created_at']);
+        // Check if the data is already cached to avoid querying the database
+        // multiple times. Once for total visits and once for unique visitors.
+        if ($this->visitsData === null) {
+            $this->visitsData = Visit::query()
+                ->when($this->model instanceof User, function ($query) {
+                    $query->whereRelation('url', 'user_id', $this->model->id);
+                })
+                ->when($this->model instanceof Url, function ($query) {
+                    $query->where('url_id', $this->model->id);
+                })
+                ->whereBetween('created_at', [$period->getStartDate(), $period->getEndDate()])
+                ->get(['user_uid', 'created_at']);
+        }
+
+        return $this->visitsData;
     }
 }


### PR DESCRIPTION
This PR optimizes the chart components by preventing the execution of duplicate database queries during a single render cycle.

**The Problem:**
The `BaseLinkVisitChart::getData()` method prepares two datasets for each chart: one for total 'Visits' and another for unique 'Visitors'. To do this, it calls the `chartData()` method twice.

```php
// In app\Livewire\Chart\BaseLinkVisitChart.php
protected function getData(): array
{
    return [
        'datasets' => [
            [
                'label' => 'Visits',
                'data' => $this->chartData(), // <-- First call
                // ...
            ],
            [
                'label' => 'Visitors',
                'data' => $this->chartData(visitor: true), // <-- Second call
                // ...
            ],
        ],
        'labels' => $this->chartLabel(),
    ];
}

// In child chart components (e.g., app\Livewire\Chart\LinkVisitChart.php)
public function chartData(bool $visitor = false): array
{
    $period = $this->period();
    // This line always executed a new database query
    $visits = $this->getPeriodData($period);

    // ... rest of the logic
}
```

Before this change, each call to `chartData()` would in turn call `getPeriodData()`, which always executed a new database query. This resulted in the exact same `SELECT` query being run twice for every chart render, causing unnecessary database load.

**The Solution:**
To resolve this, the `getPeriodData()` method has been refactored to be idempotent. It now integrates a caching mechanism using a class property (`$visitsData`).

On the first call, the method queries the database and stores the resulting collection in `$visitsData`. On any subsequent call within the same component lifecycle, it immediately returns the cached data from the property without hitting the database again.

This ensures that the database is queried only once per render.
