### PR TITLE
feat: Username blacklist configuration

### DIFF
--- a/app/Rules/UserRules.php
+++ b/app/Rules/UserRules.php
@@ -13,6 +13,7 @@ class UserRules
             'string', 'alpha_num:ascii', 'min:4', 'max:20',
             'unique:App\Models\User,name',
             Rule::notIn(['guest', 'guests']),
+            Rule::notIn(config('urlhub.username_blacklist')),
         ];
     }
 

--- a/config/urlhub.php
+++ b/config/urlhub.php
@@ -31,4 +31,8 @@ return [
      * The HTTP status code to use when redirecting a visitor to the original URL.
      */
     'redirection_status_code' => 302,
+
+    'username_blacklist' => [
+        // 'advertise',
+    ],
 ];

--- a/tests/Unit/Rules/UserRulesTest.php
+++ b/tests/Unit/Rules/UserRulesTest.php
@@ -21,11 +21,24 @@ class UserRulesTest extends TestCase
     #[PHPUnit\TestWith(['foÖ123'])] // non-ascii
     #[PHPUnit\TestWith(['foo_123'])]
     #[PHPUnit\TestWith(['foo-123'])]
-    #[PHPUnit\TestWith(['guest'])]
-    #[PHPUnit\TestWith(['guests'])]
     public function testNameFail($value): void
     {
         $val = validator(['name' => $value], ['name' => UserRules::name()]);
+        $this->assertTrue($val->fails());
+    }
+
+    #[PHPUnit\TestWith(['guest'])]
+    #[PHPUnit\TestWith(['guests'])]
+    public function testNameFail_Blacklist_Guest($value): void
+    {
+        $val = validator(['name' => $value], ['name' => UserRules::name()]);
+        $this->assertTrue($val->fails());
+    }
+
+    public function testNameFail_Blacklist_Config(): void
+    {
+        config(['urlhub.username_blacklist' => ['laravel']]);
+        $val = validator(['name' => 'laravel'], ['name' => UserRules::name()]);
         $this->assertTrue($val->fails());
     }
 


### PR DESCRIPTION

This PR introduces a new feature that allows administrators to define a list of forbidden usernames. A new configuration array `urlhub.username_blacklist` has been added. Any string added to this array will be prevented from being used as a username.

This enhancement prevents users from registering with reserved or inappropriate usernames.