### PR TITLE
fix: get all case variants of disallowed keywords present in database

### DIFF
--- a/app/Services/KeyGeneratorService.php
+++ b/app/Services/KeyGeneratorService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Url;
 use App\Settings\GeneralSettings;
+use Illuminate\Support\Facades\DB;
 
 class KeyGeneratorService
 {
@@ -152,8 +153,11 @@ class KeyGeneratorService
      */
     public function disallowedKeywordsInUse()
     {
-        return $this->disallowedKeyword()
-            ->intersect(Url::pluck('keyword'));
+        $disallowed = $this->disallowedKeyword()
+            ->map(fn($value) => strtolower($value));
+
+        return Url::whereIn(DB::raw('LOWER(keyword)'), $disallowed)
+            ->pluck('keyword');
     }
 
     /*

--- a/tests/Unit/Services/KeyGeneratorServiceTest.php
+++ b/tests/Unit/Services/KeyGeneratorServiceTest.php
@@ -204,13 +204,17 @@ class KeyGeneratorServiceTest extends TestCase
         $this->assertEmpty($this->keyGen->disallowedKeywordsInUse()->all());
 
         // Test case 2: Some reserved keywords already in use
-        $activeKeyword = 'disallowed_keyword';
-        Url::factory()->create(['keyword' => $activeKeyword]);
-        config(['urlhub.blacklist_keyword' => [$activeKeyword]]);
+        $keywordLowerCase = 'laravel';
+        $keywordUpperCase = 'Laravel';
+        $otherKeyword = 'some_other_keyword';
+        Url::factory()->create(['keyword' => $keywordLowerCase]);
+        Url::factory()->create(['keyword' => $keywordUpperCase]);
+        Url::factory()->create(['keyword' => $otherKeyword]);
+        config(['urlhub.blacklist_keyword' => [$keywordLowerCase]]);
 
-        $this->assertEquals(
-            $activeKeyword,
-            $this->keyGen->disallowedKeywordsInUse()->implode(''),
+        $this->assertEqualsCanonicalizing(
+            [$keywordLowerCase, $keywordUpperCase],
+            $this->keyGen->disallowedKeywordsInUse()->all(),
         );
     }
 


### PR DESCRIPTION
**Why**
Previously, `disallowedKeywordsInUse()` only returned exact case matches of blacklisted keywords found in the database.

For example, if `urlhub.blacklist_keyword` contained `'laravel'` and the database contained both `'laravel'` and `'LARAVEL'`, the method would only return `['laravel']`. This resulted in incomplete detection of disallowed keywords.

**What's Changed**
- Updated `disallowedKeywordsInUse()` to perform a **case-insensitive** match against the database. This ensures that **all** case variants (e.g., `'laravel'`, `'Laravel'`, `'LARAVEL'`) are detected and returned.
- Unit tests have been modified to include scenarios where both lowercase and uppercase variants are present in the database.

**Impact**
- Improved reliability for finding disallowed keywords in the database.

**Before:**
<img width="373" height="68" alt="Pasted image 20250814233314" src="https://github.com/user-attachments/assets/d079a60f-4e7b-429c-80c8-7d2ba22a0cca" />

**After**
<img width="375" height="73" alt="Pasted image 20250814233400" src="https://github.com/user-attachments/assets/a92b7964-15d3-473a-89cb-bb0e902e760c" />

**Related:**
- https://github.com/realodix/urlhub/pull/1020
