### PR TITLE
fix: secure link deletion

### DIFF
--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -128,24 +128,21 @@ class LinkController extends Controller implements HasMiddleware
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function delete(Url $url)
+    public function delete(Request $request, Url $url)
     {
         Gate::authorize('authorOrAdmin', $url);
-
         $url->delete();
 
         $message = 'Link was successfully deleted.';
 
-        // if requst from shorten url details page, return to home
-        if (request()->routeIs('link_detail.delete')) {
+        if ($request->redirect_to === 'home') {
             return to_route('home');
         }
-
-        if (request()->routeIs('link.delete.fromTable')) {
-            return redirect()->back()->with('flash_success', $message);
+        if ($request->redirect_to === 'dashboard') {
+            return to_route('dashboard')->with('flash_success', $message);
         }
 
-        return to_route('dashboard')->with('flash_success', $message);
+        return redirect()->back()->with('flash_success', $message);
     }
 
     /**

--- a/app/Livewire/Table/BaseUrlTable.php
+++ b/app/Livewire/Table/BaseUrlTable.php
@@ -87,7 +87,7 @@ abstract class BaseUrlTable extends PowerGridComponent
             ->add('action', function (Url $url) {
                 return view('components.table.action-button', [
                     'detail_link' => route('link_detail', $url->keyword),
-                    'delete_link' => route('link.delete.fromTable', $url),
+                    'delete_link' => route('link.delete', $url),
                 ])->render();
             });
     }

--- a/resources/views/backend/edit.blade.php
+++ b/resources/views/backend/edit.blade.php
@@ -32,7 +32,6 @@
             <div class="inline sm:block text-sm text-red-600 dark:text-red-500 mt-4">
                 <form method="post" action="{{ route('link.delete', $url) }}"
                     onsubmit="return confirm('Are you sure you want to delete this link?');"
-                    class="inline"
                 >
                     @csrf @method('DELETE')
                     <input type="hidden" name="redirect_to" value="dashboard">

--- a/resources/views/backend/edit.blade.php
+++ b/resources/views/backend/edit.blade.php
@@ -30,12 +30,17 @@
             @endif
 
             <div class="inline sm:block text-sm text-red-600 dark:text-red-500 mt-4">
-                @svg('icon-trash', 'mr-1')
-                <a role="button" href="{{ route('link.delete', $url) }}" title="Delete"
-                    onclick="return confirm('Are you sure you want to delete this link?');"
+                <form method="post" action="{{ route('link.delete', $url) }}"
+                    onsubmit="return confirm('Are you sure you want to delete this link?');"
+                    class="inline"
                 >
-                    Delete
-                </a>
+                    @csrf @method('DELETE')
+                    <input type="hidden" name="redirect_to" value="dashboard">
+                    <button type="submit" class="text-red-600 dark:text-red-500 hover:underline">
+                        @svg('icon-trash', 'mr-1')
+                        Delete
+                    </button>
+                </form>
             </div>
         </div>
     </div>

--- a/resources/views/components/table/action-button.blade.php
+++ b/resources/views/components/table/action-button.blade.php
@@ -4,10 +4,13 @@
     >
         @svg('icon-item-detail')
     </a>
-    <a role="button" href="{{ $delete_link }}" title="Delete"
-        class="btn btn-delete btn-square btn-xs"
-        onclick="return confirm('Are you sure you want to delete this link?');"
+    <form method="post" action="{{ $delete_link }}"
+        onsubmit="return confirm('Are you sure you want to delete this link?');"
+        class="inline"
     >
-        @svg('icon-trash')
-    </a>
+        @csrf @method('DELETE')
+        <button type="submit" title="Delete" class="btn btn-delete btn-square btn-xs">
+            @svg('icon-trash')
+        </button>
+    </form>
 </div>

--- a/resources/views/components/table/action-button.blade.php
+++ b/resources/views/components/table/action-button.blade.php
@@ -4,6 +4,7 @@
     >
         @svg('icon-item-detail')
     </a>
+
     <form method="post" action="{{ $delete_link }}"
         onsubmit="return confirm('Are you sure you want to delete this link?');"
         class="inline"

--- a/resources/views/frontend/short.blade.php
+++ b/resources/views/frontend/short.blade.php
@@ -46,12 +46,16 @@
                         <a href="{{ route('link.edit', $url) }}" title="Edit" class="btn btn-secondary btn-square btn-sm mr-6">
                             @svg('icon-edit')
                         </a>
-                        <a href="{{ route('link_detail.delete', $url) }}" title="Delete"
-                            onclick="return confirm('Are you sure you want to delete this link?');"
-                            class="btn btn-delete btn-square btn-sm"
+                        <form method="post" action="{{ route('link.delete', $url) }}"
+                            onsubmit="return confirm('Are you sure you want to delete this link?');"
+                            class="inline"
                         >
-                            @svg('icon-trash')
-                        </a>
+                            @csrf @method('DELETE')
+                            <input type="hidden" name="redirect_to" value="home">
+                            <button type="submit" title="Delete" class="btn btn-delete btn-square btn-sm">
+                                @svg('icon-trash')
+                            </button>
+                        </form>
                     @endif
                 </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Facades\Route;
 Route::view('/', 'frontend.homepage')->name('home');
 Route::post('/shorten', [LinkController::class, 'create'])->name('link.create');
 Route::get('/+{url:keyword}', [LinkController::class, 'showDetail'])->name('link_detail');
-Route::get('/delete/{url:keyword}', [LinkController::class, 'delete'])->name('link_detail.delete');
 
 Route::prefix('admin')->middleware(['auth', 'auth.session'])->group(function () {
     // Dashboard (My URLs)
@@ -25,8 +24,7 @@ Route::prefix('admin')->middleware(['auth', 'auth.session'])->group(function () 
 
         Route::get('/edit/{url:keyword}', [LinkController::class, 'edit'])->name('link.edit');
         Route::post('/edit/{url:keyword}', [LinkController::class, 'update'])->name('link.update');
-        Route::get('/delete/{url:keyword}', [LinkController::class, 'delete'])->name('link.delete');
-        Route::get('/table/delete/{url:keyword}', [LinkController::class, 'delete'])->name('link.delete.fromTable');
+        Route::delete('/delete/{url:keyword}', [LinkController::class, 'delete'])->name('link.delete');
         Route::post('/password/store/{url:keyword}', [LinkPasswordController::class, 'store'])->name('link.password.store');
         Route::post('/password/update/{url:keyword}', [LinkPasswordController::class, 'update'])->name('link.password.update');
         Route::get('/password/delete/{url:keyword}', [LinkPasswordController::class, 'delete'])->name('link.password.delete');

--- a/tests/Feature/AuthPage/DashboardPageTest.php
+++ b/tests/Feature/AuthPage/DashboardPageTest.php
@@ -33,7 +33,10 @@ class DashboardPageTest extends TestCase
     {
         $url = Url::factory()->create();
         $response = $this->actingAs($url->author)
-            ->get(route('link.delete', $url->keyword));
+            ->delete(
+                route('link.delete', $url->keyword),
+                ['redirect_to' => 'dashboard'],
+            );
 
         $response
             ->assertRedirectToRoute('dashboard')
@@ -54,7 +57,7 @@ class DashboardPageTest extends TestCase
         $url = Url::factory()->create();
         $response = $this->actingAs($url->author)
             ->from(route($route))
-            ->get(route('link.delete.fromTable', $url->keyword));
+            ->delete(route('link.delete', $url->keyword));
 
         $response
             ->assertRedirectToRoute($route)

--- a/tests/Feature/AuthPage/LinkAuthorizationTest.php
+++ b/tests/Feature/AuthPage/LinkAuthorizationTest.php
@@ -114,7 +114,7 @@ class LinkAuthorizationTest extends TestCase
         $url = Url::factory()->create();
         $response = $this->actingAs($this->adminUser())
             ->from(route('dboard.allurl'))
-            ->get(route('link.delete.fromTable', $url->keyword));
+            ->delete(route('link.delete', $url->keyword));
 
         $response->assertRedirectToRoute('dboard.allurl')
             ->assertSessionHas('flash_success');
@@ -132,7 +132,7 @@ class LinkAuthorizationTest extends TestCase
         $url = Url::factory()->create();
         $response = $this->actingAs($this->basicUser())
             ->from(route('dboard.allurl'))
-            ->get(route('link.delete', $url->keyword));
+            ->delete(route('link.delete', $url->keyword));
 
         $response->assertForbidden();
         $this->assertCount(1, Url::all());

--- a/tests/Feature/FrontPage/ShortenUrl/DeleteShortLinkTest.php
+++ b/tests/Feature/FrontPage/ShortenUrl/DeleteShortLinkTest.php
@@ -9,6 +9,8 @@ use Tests\TestCase;
 #[\PHPUnit\Framework\Attributes\Group('front-page')]
 class DeleteShortLinkTest extends TestCase
 {
+    const ROUTE_DEL_PARAM = ['redirect_to' => 'home'];
+
     #[PHPUnit\Test]
     public function delete_OwnedLink_ByUser_WillBeOk(): void
     {
@@ -16,7 +18,7 @@ class DeleteShortLinkTest extends TestCase
 
         $response = $this->actingAs($url->author)
             ->from(route('link_detail', $url->keyword))
-            ->get(route('link_detail.delete', $url->keyword));
+            ->delete(route('link.delete', $url->keyword), self::ROUTE_DEL_PARAM);
 
         $response->assertRedirectToRoute('home');
         $this->assertCount(0, Url::all());
@@ -31,18 +33,18 @@ class DeleteShortLinkTest extends TestCase
     {
         $url = Url::factory()->guest()->create();
         $response = $this->from(route('link_detail', $url->keyword))
-            ->get(route('link_detail.delete', $url->keyword));
-        $response->assertForbidden();
+            ->delete(route('link.delete', $url->keyword), self::ROUTE_DEL_PARAM);
+        $response->assertRedirectToRoute('login');
 
         $url = Url::factory()->create(['user_id' => $this->adminUser()->id]);
         $response = $this->from(route('link_detail', $url->keyword))
-            ->get(route('link_detail.delete', $url->keyword));
-        $response->assertForbidden();
+            ->delete(route('link.delete', $url->keyword), self::ROUTE_DEL_PARAM);
+        $response->assertRedirectToRoute('login');
 
         $url = Url::factory()->create();
         $response = $this->from(route('link_detail', $url->keyword))
-            ->get(route('link_detail.delete', $url->keyword));
-        $response->assertForbidden();
+            ->delete(route('link.delete', $url->keyword), self::ROUTE_DEL_PARAM);
+        $response->assertRedirectToRoute('login');
 
         $this->assertCount(3, Url::all());
     }
@@ -58,7 +60,7 @@ class DeleteShortLinkTest extends TestCase
         $url = Url::factory()->create();
         $response = $this->actingAs($this->adminUser())
             ->from(route('link_detail', $url->keyword))
-            ->get(route('link_detail.delete', $url->keyword));
+            ->delete(route('link.delete', $url->keyword), self::ROUTE_DEL_PARAM);
 
         $response->assertRedirectToRoute('home');
         $this->assertCount(0, Url::all());
@@ -74,7 +76,7 @@ class DeleteShortLinkTest extends TestCase
         $url = Url::factory()->guest()->create();
         $response = $this->actingAs($this->adminUser())
             ->from(route('link_detail', $url->keyword))
-            ->get(route('link_detail.delete', $url->keyword));
+            ->delete(route('link.delete', $url->keyword), self::ROUTE_DEL_PARAM);
 
         $response->assertRedirectToRoute('home');
         $this->assertCount(0, Url::all());
@@ -90,7 +92,7 @@ class DeleteShortLinkTest extends TestCase
         $url = Url::factory()->create();
         $response = $this->actingAs($this->basicUser())
             ->from(route('link_detail', $url->keyword))
-            ->get(route('link_detail.delete', $url->keyword));
+            ->delete(route('link.delete', $url->keyword), self::ROUTE_DEL_PARAM);
 
         $response->assertForbidden();
         $this->assertCount(1, Url::all());
@@ -106,7 +108,7 @@ class DeleteShortLinkTest extends TestCase
         $url = Url::factory()->guest()->create();
         $response = $this->actingAs($this->basicUser())
             ->from(route('link_detail', $url->keyword))
-            ->get(route('link_detail.delete', $url->keyword));
+            ->delete(route('link.delete', $url->keyword), self::ROUTE_DEL_PARAM);
 
         $response->assertForbidden();
         $this->assertCount(1, Url::all());


### PR DESCRIPTION
Converted the link deletion action from a `GET` to a `DELETE` request to prevent CSRF vulnerabilities.

Additionally, it consolidates three separate deletion routes (`link.delete`, `link_detail.delete`, and `link.delete.fromTable`) into a single, unified `link.delete` route.