### PR TITLE
fix: secure link password deletion

### DIFF
--- a/resources/views/backend/edit.blade.php
+++ b/resources/views/backend/edit.blade.php
@@ -136,7 +136,9 @@
                                         @svg('icon-key', 'mr-1') Edit Password
                                     </button>
 
-                                    <button type="button" x-on:click="$dispatch('open-modal', 'remove-password-modal')" class="btn btn-delete-danger btn-sm dark:text-red-700! dark:hover:text-red-400! dark:border-red-900!">
+                                    <button type="button" x-on:click="$dispatch('open-modal', 'remove-password-modal')"
+                                        class="btn btn-delete-danger btn-sm dark:text-red-700! dark:hover:text-red-400! dark:border-red-900!"
+                                    >
                                         Remove Password
                                     </button>
                                 @else

--- a/resources/views/backend/edit.blade.php
+++ b/resources/views/backend/edit.blade.php
@@ -136,9 +136,9 @@
                                         @svg('icon-key', 'mr-1') Edit Password
                                     </button>
 
-                                    <a href="{{ route('link.password.delete', $url) }}" onclick="return confirm('Are you sure you want to remove the password?')" class="btn btn-delete-danger btn-sm dark:text-red-700! dark:hover:text-red-400! dark:border-red-900!">
+                                    <button type="button" x-on:click="$dispatch('open-modal', 'remove-password-modal')" class="btn btn-delete-danger btn-sm dark:text-red-700! dark:hover:text-red-400! dark:border-red-900!">
                                         Remove Password
-                                    </a>
+                                    </button>
                                 @else
                                     <button type="button" title="Add Password" x-on:click="$dispatch('open-modal', 'add-password-modal')" class="btn btn-sm">
                                         @svg('icon-key', 'mr-1') Add Password
@@ -209,6 +209,26 @@
         @include('backend.linkpassword.create')
     @else
         @include('backend.linkpassword.edit')
+
+        <x-modal name="remove-password-modal" maxWidth="md">
+            <x-slot:title>Remove Password for <span class="font-semibold">{{ $url->keyword }}</span></x-slot:title>
+            <form method="post" action="{{ route('link.password.delete', $url) }}" class="space-y-6">
+                @csrf @method('DELETE')
+                <p class="font-light text-sm dark:text-dark-400 mt-2 mb-2">
+                    Are you sure you want to remove the password for this link? This action cannot be undone.
+                </p>
+
+                <div class="flex justify-end items-center">
+                    <button type="button"
+                        x-on:click="$dispatch('close-modal', 'remove-password-modal')"
+                        class="btn btn-secondary mr-2"
+                    >
+                        Cancel
+                    </button>
+                    <button type="submit" class="btn btn-delete-danger">Remove Password</button>
+                </div>
+            </form>
+        </x-modal>
     @endif
 </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,7 @@ Route::prefix('admin')->middleware(['auth', 'auth.session'])->group(function () 
         Route::get('/table/delete/{url:keyword}', [LinkController::class, 'delete'])->name('link.delete.fromTable');
         Route::post('/password/store/{url:keyword}', [LinkPasswordController::class, 'store'])->name('link.password.store');
         Route::post('/password/update/{url:keyword}', [LinkPasswordController::class, 'update'])->name('link.password.update');
-        Route::get('/password/delete/{url:keyword}', [LinkPasswordController::class, 'delete'])->name('link.password.delete');
+        Route::delete('/password/delete/{url:keyword}', [LinkPasswordController::class, 'delete'])->name('link.password.delete');
         Route::get('/tag/restricted', [DashboardController::class, 'restrictedLinkView'])->name('dboard.links.restricted');
         Route::get('/tag/restricted/{user:name}', [DashboardController::class, 'userRestrictedLinkView'])
             ->name('dboard.links.user.restricted');

--- a/tests/Feature/AuthPage/LinkAuthorizationTest.php
+++ b/tests/Feature/AuthPage/LinkAuthorizationTest.php
@@ -196,7 +196,7 @@ class LinkAuthorizationTest extends TestCase
     {
         $url = Url::factory()->create(['password' => 'password']);
         $this->actingAs($this->adminUser())
-            ->get(route('link.password.delete', $url));
+            ->delete(route('link.password.delete', $url));
 
         $this->assertNull($url->fresh()->password);
     }

--- a/tests/Feature/AuthPage/LinkTest.php
+++ b/tests/Feature/AuthPage/LinkTest.php
@@ -247,7 +247,7 @@ class LinkTest extends TestCase
         $url = Url::factory()->create(['password' => 'password']);
         $response = $this->actingAs($url->author)
             ->from(route('link.edit', $url))
-            ->get(route('link.password.delete', $url));
+            ->delete(route('link.password.delete', $url));
 
         $response
             ->assertRedirectToRoute('link.edit', $url)


### PR DESCRIPTION
Converted the link password deletion action from a `GET` to a `DELETE` request to prevent CSRF vulnerabilities.