### PR TITLE
feat: don’t redirect shortlinks to blacklisted domains

### DIFF
--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\RedirectToDestination;
+use App\Helpers\Helper;
 use App\Models\Url;
 use Illuminate\Support\Facades\Gate;
 
@@ -29,6 +30,11 @@ class RedirectController extends Controller
             }
 
             return to_route('link.expired', $url);
+        }
+
+        // Check if the domain is in the blacklist
+        if (Helper::isDomainBlacklisted($url->destination)) {
+            return abort(404);
         }
 
         return app(RedirectToDestination::class)->handle($url);

--- a/tests/Feature/FrontPage/VisitTest.php
+++ b/tests/Feature/FrontPage/VisitTest.php
@@ -301,4 +301,26 @@ class VisitTest extends TestCase
         $response = $this->get(route('link.expired', $url));
         $response->assertRedirect(route('link_detail', $url->keyword));
     }
+
+    /**
+     * When a link has a blacklisted domain, it should be redirected
+     * to the landing page.
+     *
+     * @see \App\Http\Controllers\RedirectController::__invoke()
+     */
+    #[PHPUnit\Test]
+    public function linkHasBlacklistedDomain()
+    {
+        // Test case 1: domain is not blacklisted
+        $url = Url::factory()->create([
+            'destination' => 'https://laravel.com/docs',
+        ]);
+        $response = $this->get($url->keyword);
+        $response->assertStatus(config('urlhub.redirection_status_code'));
+
+        // Test case 2: domain is blacklisted
+        config(['urlhub.blacklist_domain' => ['laravel.com']]);
+        $response = $this->get($url->keyword);
+        $response->assertNotFound();
+    }
 }


### PR DESCRIPTION
Prevent redirecting URLs if the destination domain is listed in the blacklist.